### PR TITLE
feat: send errors to sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@aws-sdk/client-s3": "^3.75.0",
     "@fleekhq/fleek-storage-js": "^1.0.21",
     "@pinata/sdk": "^1.1.25",
+    "@sentry/node": "^7.57.0",
     "bluebird": "^3.7.2",
     "cors": "^2.8.5",
     "cross-fetch": "^3.1.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import express from 'express';
+import { initLogger, fallbackLogger } from './sentry';
 import cors from 'cors';
 import rpc from './rpc';
 import upload from './upload';
@@ -10,6 +11,8 @@ import { stats } from './stats';
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+initLogger(app);
+
 app.use(express.json({ limit: '4mb' }));
 app.use(express.urlencoded({ limit: '4mb', extended: false }));
 app.use(cors({ maxAge: 86400 }));
@@ -17,5 +20,7 @@ app.use('/', rpc);
 app.use('/', upload);
 app.use('/', proxy);
 app.get('/', (req, res) => res.json({ version, port: PORT, stats }));
+
+fallbackLogger(app);
 
 app.listen(PORT, () => console.log(`Listening at http://localhost:${PORT}`));

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,7 @@ import Promise from 'bluebird';
 import gateways from './gateways.json';
 import { set, get } from './aws';
 import { MAX, sha256 } from './utils';
+import { capture } from './sentry';
 
 const router = express.Router();
 
@@ -22,6 +23,7 @@ router.get('/ipfs/*', async (req, res) => {
     const size = Buffer.from(JSON.stringify(json)).length;
     if (size <= MAX) await set(`cache/${key}`, json);
   } catch (e) {
+    capture(e);
     return res.status(500).json();
   }
 });

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -8,6 +8,7 @@ import { set as setWeb3Storage } from './providers/web3storage';
 import { set as set4everland } from './providers/4everland';
 import { set as setAws } from './aws';
 import { stats } from './stats';
+import { capture } from './sentry';
 
 const router = express.Router();
 
@@ -29,7 +30,7 @@ router.post('/', async (req, res) => {
     result.size = size;
     return rpcSuccess(res, result, id);
   } catch (e) {
-    console.log(e);
+    capture(e);
     return rpcError(res, 500, e, id);
   }
 });

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -22,6 +22,8 @@ export function initLogger(app: Express) {
 }
 
 export function fallbackLogger(app: Express) {
+  if (process.env.NODE_ENV !== 'production') return;
+  
   app.use(Sentry.Handlers.errorHandler());
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use(function onError(err: any, req: any, res: any, _: any) {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -23,7 +23,7 @@ export function initLogger(app: Express) {
 
 export function fallbackLogger(app: Express) {
   if (process.env.NODE_ENV !== 'production') return;
-  
+
   app.use(Sentry.Handlers.errorHandler());
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use(function onError(err: any, req: any, res: any, _: any) {
@@ -33,5 +33,9 @@ export function fallbackLogger(app: Express) {
 }
 
 export function capture(e: any) {
+  if (process.env.NODE_ENV !== 'production') {
+    return console.error(e);
+  }
+
   Sentry.captureException(e);
 }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -2,6 +2,10 @@ import * as Sentry from '@sentry/node';
 import type { Express } from 'express';
 
 export function initLogger(app: Express) {
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     integrations: [

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,0 +1,31 @@
+import * as Sentry from '@sentry/node';
+import type { Express } from 'express';
+
+export function initLogger(app: Express) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    integrations: [
+      new Sentry.Integrations.Http({ tracing: true }),
+      new Sentry.Integrations.Express({ app }),
+      ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations()
+    ],
+
+    tracesSampleRate: parseFloat(process.env.SENTRY_TRACE_SAMPLE_RATE as string)
+  });
+
+  app.use(Sentry.Handlers.requestHandler());
+  app.use(Sentry.Handlers.tracingHandler());
+}
+
+export function fallbackLogger(app: Express) {
+  app.use(Sentry.Handlers.errorHandler());
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use(function onError(err: any, req: any, res: any, _: any) {
+    res.statusCode = 500;
+    res.end(`${res.sentry}\n`);
+  });
+}
+
+export function capture(e: any) {
+  Sentry.captureException(e);
+}

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -8,19 +8,27 @@ import { set as setFleek } from './providers/fleek';
 import { set as setInfura } from './providers/infura';
 import { set as setPinata } from './providers/pinata';
 import { set as set4everland } from './providers/4everland';
+import { capture } from './sentry';
 
 const MAX_INPUT_SIZE = 1024 * 1024;
 const MAX_IMAGE_DIMENSION = 1500;
 
 const router = express.Router();
-const upload = multer({ dest: 'uploads/', limits: { fileSize: MAX_INPUT_SIZE } });
+const upload = multer({
+  dest: 'uploads/',
+  limits: { fileSize: MAX_INPUT_SIZE }
+});
 
 router.post('/upload', upload.single('file'), async (req, res) => {
   if (!req.file) return rpcError(res, 500, 'no file', null);
 
   try {
     const transformer = sharp()
-      .resize({ width: MAX_IMAGE_DIMENSION, height: MAX_IMAGE_DIMENSION, fit: 'inside' })
+      .resize({
+        width: MAX_IMAGE_DIMENSION,
+        height: MAX_IMAGE_DIMENSION,
+        fit: 'inside'
+      })
       .webp({ lossless: true });
 
     const buffer = await fs.createReadStream(req.file.path).pipe(transformer).toBuffer();
@@ -37,7 +45,7 @@ router.post('/upload', upload.single('file'), async (req, res) => {
     console.log('Upload success', result.provider, result.cid);
     return rpcSuccess(res, file, null);
   } catch (e) {
-    console.log(e);
+    capture(e);
     return rpcError(res, 500, e, null);
   } finally {
     await fs.promises.unlink(req.file.path);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,52 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@sentry-internal/tracing@7.57.0":
+  version "7.57.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.57.0.tgz#cb761931b635f8f24c84be0eecfacb8516b20551"
+  integrity sha512-tpViyDd8AhQGYYhI94xi2aaDopXOPfL2Apwrtb3qirWkomIQ2K86W1mPmkce+B0cFOnW2Dxv/ZTFKz6ghjK75A==
+  dependencies:
+    "@sentry/core" "7.57.0"
+    "@sentry/types" "7.57.0"
+    "@sentry/utils" "7.57.0"
+    tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/core@7.57.0":
+  version "7.57.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.57.0.tgz#65093d739c04f320a54395a21be955fcbe326acb"
+  integrity sha512-l014NudPH0vQlzybtXajPxYFfs9w762NoarjObC3gu76D1jzBBFzhdRelkGpDbSLNTIsKhEDDRpgAjBWJ9icfw==
+  dependencies:
+    "@sentry/types" "7.57.0"
+    "@sentry/utils" "7.57.0"
+    tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/node@^7.57.0":
+  version "7.57.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.57.0.tgz#31052f5988ed4496d7f3ff925240cf9b02d09941"
+  integrity sha512-63mjyUVM6sfJFVQ5TGVRVGUsoEfESl5ABzIW1W0s9gUiQPaG8SOdaQJglb2VNrkMYxnRHgD8Q9LUh/qcmUyPGw==
+  dependencies:
+    "@sentry-internal/tracing" "7.57.0"
+    "@sentry/core" "7.57.0"
+    "@sentry/types" "7.57.0"
+    "@sentry/utils" "7.57.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/types@7.57.0":
+  version "7.57.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.57.0.tgz#4fdb80cbd49ba034dd8d9be0c0005a016d5db3ce"
+  integrity sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==
+
+"@sentry/utils@7.57.0":
+  version "7.57.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.57.0.tgz#8253c6fcf35138b4c424234b8da1596e11b98ad8"
+  integrity sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==
+  dependencies:
+    "@sentry/types" "7.57.0"
+    tslib "^2.4.1 || ^1.9.3"
+
 "@sinclair/typebox@^0.23.3":
   version "0.23.5"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
@@ -1986,6 +2032,13 @@ acorn@^8.4.1:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.10.0, ajv@^6.10.2:
   version "6.12.6"
@@ -2715,6 +2768,11 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -2785,19 +2843,19 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -3692,6 +3750,14 @@ http-errors@2.0.0:
     setprototypeof "1.2.0"
     statuses "2.0.1"
     toidentifier "1.0.1"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -4994,6 +5060,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
 mafmt@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-7.1.0.tgz#4126f6d0eded070ace7dbbb6fb04977412d380b5"
@@ -5367,16 +5438,16 @@ node-addon-api@^5.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
   integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
 
-"node-fetch@https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz":
-  version "2.6.7"
-  resolved "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz#1b5d62978f2ed07b99444f64f0df39f960a6d34d"
-
 node-fetch@^2.6.1, node-fetch@^2.6.11:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
   integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
+
+"node-fetch@https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz":
+  version "2.6.7"
+  resolved "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz#1b5d62978f2ed07b99444f64f0df39f960a6d34d"
 
 node-forge@^1.2.1:
   version "1.3.1"
@@ -6698,6 +6769,11 @@ tslib@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+"tslib@^2.4.1 || ^1.9.3":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 tsutils@^3.17.1:
   version "3.21.0"


### PR DESCRIPTION
Send errors to sentry

- Add logger to log all uncaught errors
- Refactor code to send caught errors to sentry, instead of `console.log`