### PR TITLE
fix: fix file size exceeding limits error not being handled

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -17,38 +17,46 @@ const router = express.Router();
 const upload = multer({
   dest: 'uploads/',
   limits: { fileSize: MAX_INPUT_SIZE }
-});
+}).single('file');
 
-router.post('/upload', upload.single('file'), async (req, res) => {
-  if (!req.file) return rpcError(res, 500, 'no file', null);
-
+router.post('/upload', async (req, res) => {
   try {
-    const transformer = sharp()
-      .resize({
-        width: MAX_IMAGE_DIMENSION,
-        height: MAX_IMAGE_DIMENSION,
-        fit: 'inside'
-      })
-      .webp({ lossless: true });
+    upload(req, res, async err => {
+      if (err) return rpcError(res, 500, err.message, null);
+      if (!req.file) return rpcError(res, 500, 'no file', null);
 
-    const buffer = await fs.createReadStream(req.file.path).pipe(transformer).toBuffer();
-    const result = await Promise.any([
-      setFleek(buffer),
-      setInfura(buffer),
-      setPinata(buffer),
-      set4everland(buffer)
-    ]);
-    const file = {
-      cid: result.cid,
-      provider: result.provider
-    };
-    console.log('Upload success', result.provider, result.cid);
-    return rpcSuccess(res, file, null);
+      const transformer = sharp()
+        .resize({
+          width: MAX_IMAGE_DIMENSION,
+          height: MAX_IMAGE_DIMENSION,
+          fit: 'inside'
+        })
+        .webp({ lossless: true });
+
+      const buffer = await fs
+        .createReadStream(req.file?.path as string)
+        .pipe(transformer)
+        .toBuffer();
+      const result = await Promise.any([
+        setFleek(buffer),
+        setInfura(buffer),
+        setPinata(buffer),
+        set4everland(buffer)
+      ]);
+      const file = {
+        cid: result.cid,
+        provider: result.provider
+      };
+      console.log('Upload success', result.provider, result.cid);
+      return rpcSuccess(res, file, null);
+    });
   } catch (e) {
     capture(e);
     return rpcError(res, 500, e, null);
   } finally {
-    await fs.promises.unlink(req.file.path);
+    if (req.file) {
+      await fs.promises.unlink(req.file.path as string);
+    }
   }
 });
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When uploading a file too big, it returns an unhandled 500 error from express.

## 💊 Fixes / Solution

We should try/catch the error, and return the error in JSON RPC format, like the other errors.

Fix #140 
Fixes PINEAPPLE-1
 
## 🚧 Changes

- Move multer from middleware to being inside the request, so we can have access to the error object
- Return an JSON RPC error with a meaninful message when the file is too large

## 🛠️ Tests

- Use postman to test file upload
- BEFORE fix: it returns an unhandled 500 HTML error
- AFTER fix: it returns a handled JSON RPC error