### PR TITLE
fix: improve error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Pineapple
+
+## Error codes
+
+All endpoints will respond with a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) error response on error:
+
+```bash
+{
+  "jsonrpc":"2.0",
+  "error":{
+    "code": CODE,
+    "message": MESSAGE
+  },
+  "id": ID
+}
+```
+
+| Description                                                     | `CODE` | `MESSAGE`                                   |
+| --------------------------------------------------------------- | ------ | ------------------------------------------- |
+| Uploaded file exceed 1MB                                        | 400    | File too large                              |
+| Uploaded image file is not an image                             | 415    | Unsupported file type                       |
+| Uploaded payload does not contain a fileSize                    | 400    | No file submitted                           |
+| Server error                                                    | 500    | (Will depend on the error)                  |                 |

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -15,7 +15,7 @@ router.post('/', async (req, res) => {
   const { id, params } = req.body;
   try {
     const size = Buffer.from(JSON.stringify(params)).length;
-    if (size > MAX) return rpcError(res, 500, 'too large', id);
+    if (size > MAX) return rpcError(res, 400, 'File too large', id);
     const result = await Promise.any([
       setFleek(params),
       setInfura(params),
@@ -28,7 +28,7 @@ router.post('/', async (req, res) => {
     console.log('Success', result.provider, 'size', size, 'ms', result.ms);
     result.size = size;
     return rpcSuccess(res, result, id);
-  } catch (e) {
+  } catch (e: any) {
     capture(e);
     return rpcError(res, 500, e, id);
   }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -22,8 +22,8 @@ const upload = multer({
 router.post('/upload', async (req, res) => {
   upload(req, res, async err => {
     try {
-      if (err) return rpcError(res, 400, err.message, null);
-      if (!req.file) return rpcError(res, 400, 'no file', null);
+      if (err) return rpcError(res, 400, err.message);
+      if (!req.file) return rpcError(res, 400, 'No file submitted');
 
       const transformer = sharp()
         .resize({
@@ -49,14 +49,14 @@ router.post('/upload', async (req, res) => {
         provider: result.provider
       };
       console.log('Upload success', result.provider, result.cid);
-      return rpcSuccess(res, file, null);
+      return rpcSuccess(res, file);
     } catch (e: any) {
       if (e.message === 'Input buffer contains unsupported image format') {
-        return rpcError(res, 415, 'Unsupported file type', null);
+        return rpcError(res, 415, 'Unsupported file type');
       }
 
       capture(e);
-      return rpcError(res, 500, e, null);
+      return rpcError(res, 500, e);
     } finally {
       if (req.file) {
         await fs.promises.unlink(req.file.path as string);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'crypto';
+import { Response } from 'express';
 
 export const MAX = 10e4;
 
-export function rpcSuccess(res, result, id) {
+export function rpcSuccess(res: Response, result: any, id = '') {
   res.json({
     jsonrpc: '2.0',
     result,
@@ -10,13 +11,13 @@ export function rpcSuccess(res, result, id) {
   });
 }
 
-export function rpcError(res, code, e, id) {
+export function rpcError(res: Response, code: number, e: Error | string, id = null) {
   res.status(code).json({
     jsonrpc: '2.0',
     error: {
       code,
-      message: 'unauthorized',
-      data: e
+      message: e,
+      data: {}
     },
     id
   });

--- a/test/e2e/upload.test.ts
+++ b/test/e2e/upload.test.ts
@@ -11,7 +11,7 @@ describe('GET /upload', () => {
         .attach('file', path.join(__dirname, './fixtures/too-heavy.jpg'));
 
       expect(response.statusCode).toBe(400);
-      expect(response.body.error.data).toContain('large');
+      expect(response.body.error.message).toBe('File too large');
     });
   });
 
@@ -25,7 +25,7 @@ describe('GET /upload', () => {
         .attach('file', path.join(__dirname, `./fixtures/${filename}`));
 
       expect(response.statusCode).toBe(415);
-      expect(response.body.error.data).toBe('Unsupported file type');
+      expect(response.body.error.message).toBe('Unsupported file type');
     });
   });
 
@@ -34,7 +34,7 @@ describe('GET /upload', () => {
       const response = await request(HOST).post('/upload');
 
       expect(response.statusCode).toBe(400);
-      expect(response.body.error.data).toBe('no file');
+      expect(response.body.error.message).toBe('No file submitted');
     });
   });
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Current error message are more code than message, and not ready to be shown directly to consumer. 

## 💊 Fixes / Solution

Improve error message, so they can be shown directly on the UI

A well formatted error response will enable us to re-throw it on pineapple.js https://github.com/snapshot-labs/pineapple.js/pull/14

## 🚧 Changes

- Improve error messages
- Return the error message in the JSON-RPC `message` field instead of data (this field was always returning `unauthorized`, no matter the error)
- Return 400 error code instead of 500 for user input errors
- Add description of error code in README

## 🛠️ Tests

- Try to test the /upload endpoint with various failing scenario
- The error message should be more useful, and formatted