### PR TITLE
feat: add metrics

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@aws-sdk/client-s3": "^3.75.0",
     "@fleekhq/fleek-storage-js": "^1.0.21",
     "@pinata/sdk": "^1.1.25",
+    "@snapshot-labs/snapshot-metrics": "^1.0.0",
     "@snapshot-labs/snapshot-sentry": "^1.0.0",
     "bluebird": "^3.7.2",
     "cors": "^2.8.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import rpc from './rpc';
 import upload from './upload';
 import proxy from './proxy';
 import { version } from '../package.json';
-import { stats } from './stats';
 import initMetrics from './metrics';
 
 const app = express();
@@ -24,7 +23,7 @@ app.use(cors({ maxAge: 86400 }));
 app.use('/', rpc);
 app.use('/', upload);
 app.use('/', proxy);
-app.get('/', (req, res) => res.json({ version: v, port: PORT, stats }));
+app.get('/', (req, res) => res.json({ version: v, port: PORT }));
 
 fallbackLogger(app);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import upload from './upload';
 import proxy from './proxy';
 import { version } from '../package.json';
 import { stats } from './stats';
+import initMetrics from './metrics';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -15,6 +16,7 @@ const commit = process.env.COMMIT_HASH || '';
 const v = commit ? `${version}#${commit.substr(0, 7)}` : version;
 
 initLogger(app);
+initMetrics(app);
 
 app.use(express.json({ limit: '4mb' }));
 app.use(express.urlencoded({ limit: '4mb', extended: false }));

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -14,3 +14,9 @@ export const timeProvidersUpload = new client.Histogram({
   labelNames: ['name'],
   buckets: [0.5, 1, 2, 5, 10, 15]
 });
+
+export const providersUploadSize = new client.Counter({
+  name: 'providers_upload_size',
+  help: "Total size of each provider's upload file",
+  labelNames: ['name']
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,15 @@
+import init, { client } from '@snapshot-labs/snapshot-metrics';
+import type { Express } from 'express';
+
+export default function initMetrics(app: Express) {
+  init(app, {
+    normalizedPath: [
+      ['^/ipfs/.*', '/ipfs/#url'],
+    ],
+    whitelistedPath: [
+      /^\/$/,
+      /^\/upload$/,
+      /^\/ipfs\/.*$/,
+    ]
+  });
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -28,6 +28,12 @@ export const providersUploadSize = new client.Counter({
   labelNames: ['name']
 });
 
+const providersReturnCount = new client.Counter({
+  name: 'providers_return_count',
+  help: 'Number of times each provider have been used',
+  labelNames: ['name']
+});
+
 export const timeIpfsGatewaysResponse = new client.Histogram({
   name: 'ipfs_gateways_response_duration_seconds',
   help: "Duration in seconds of each IPFS gateway's reponse",
@@ -40,3 +46,16 @@ export const ipfsGatewaysReturnCount = new client.Counter({
   help: 'Number of times each gateway have been used',
   labelNames: ['name']
 });
+
+export const providersInstrumentation = (req, res, next) => {
+  const oldJson = res.json;
+  res.json = body => {
+    if (res.statusCode === 200 && body) {
+      providersReturnCount.inc({ name: body.result?.provider || body.provider });
+    }
+
+    res.locals.body = body;
+    return oldJson.call(res, body);
+  };
+  next();
+};

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -34,3 +34,9 @@ export const timeIpfsGatewaysResponse = new client.Histogram({
   labelNames: ['name'],
   buckets: [0.5, 1, 2, 5, 10, 15]
 });
+
+export const ipfsGatewaysReturnCount = new client.Counter({
+  name: 'ipfs_gateways_return_count',
+  help: 'Number of times each gateway have been used',
+  labelNames: ['name']
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -3,13 +3,14 @@ import type { Express } from 'express';
 
 export default function initMetrics(app: Express) {
   init(app, {
-    normalizedPath: [
-      ['^/ipfs/.*', '/ipfs/#url'],
-    ],
-    whitelistedPath: [
-      /^\/$/,
-      /^\/upload$/,
-      /^\/ipfs\/.*$/,
-    ]
+    normalizedPath: [['^/ipfs/.*', '/ipfs/#url']],
+    whitelistedPath: [/^\/$/, /^\/upload$/, /^\/ipfs\/.*$/]
   });
 }
+
+export const timeProvidersUpload = new client.Histogram({
+  name: 'providers_upload_duration_seconds',
+  help: "Duration in seconds of provider's upload requests",
+  labelNames: ['name'],
+  buckets: [0.5, 1, 2, 5, 10, 15]
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,5 +1,6 @@
 import init, { client } from '@snapshot-labs/snapshot-metrics';
 import type { Express } from 'express';
+import gateways from './gateways.json';
 
 export default function initMetrics(app: Express) {
   init(app, {
@@ -7,6 +8,12 @@ export default function initMetrics(app: Express) {
     whitelistedPath: [/^\/$/, /^\/upload$/, /^\/ipfs\/.*$/]
   });
 }
+
+const gatewaysCount = new client.Gauge({
+  name: 'ipfs_gateways_count',
+  help: 'Number of IPFS gateways'
+});
+gatewaysCount.set(gateways.length);
 
 export const timeProvidersUpload = new client.Histogram({
   name: 'providers_upload_duration_seconds',
@@ -19,4 +26,11 @@ export const providersUploadSize = new client.Counter({
   name: 'providers_upload_size',
   help: "Total size of each provider's upload file",
   labelNames: ['name']
+});
+
+export const timeIpfsGatewaysResponse = new client.Histogram({
+  name: 'ipfs_gateways_response_duration_seconds',
+  help: "Duration in seconds of each IPFS gateway's reponse",
+  labelNames: ['name'],
+  buckets: [0.5, 1, 2, 5, 10, 15]
 });

--- a/src/providers/4everland.ts
+++ b/src/providers/4everland.ts
@@ -12,7 +12,6 @@ const client = new S3({
 });
 
 export async function set(data: Buffer | object) {
-  const start = Date.now();
   const payload = data instanceof Buffer ? data : JSON.stringify(data);
   const params = {
     Bucket: process.env.EVER_BUCKET_NAME,
@@ -25,7 +24,6 @@ export async function set(data: Buffer | object) {
   });
   const result = await client.headObject(params);
   const cid = JSON.parse(result.ETag || 'null');
-  const ms = Date.now() - start;
 
-  return { cid, provider, ms };
+  return { cid, provider };
 }

--- a/src/providers/fleek.ts
+++ b/src/providers/fleek.ts
@@ -8,13 +8,11 @@ const config: any = {
 };
 
 export async function set(data: Buffer | object) {
-  const start = Date.now();
   const input = config;
   input.data = data instanceof Buffer ? data : JSON.stringify(data);
   input.key = sha256(input.data);
   const result = await fleek.upload(input);
   const cid = result.hashV0;
-  const ms = Date.now() - start;
 
-  return { cid, provider, ms };
+  return { cid, provider };
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,7 +3,7 @@ import * as infura from './infura';
 import * as pinata from './pinata';
 import * as web3Storage from './web3storage';
 import * as fourEverland from './4everland';
-import { timeProvidersUpload } from '../metrics';
+import { timeProvidersUpload, providersUploadSize } from '../metrics';
 
 // List of providers used for pinning images
 export const IMAGE_PROVIDERS = ['fleek', 'infura', 'pinata', '4everland'];
@@ -17,12 +17,14 @@ const providersMap = {
   '4everland': fourEverland
 };
 
-export default function set(providers: string[], params?: any) {
+export default function set(providers: string[], params: any) {
   return providers.map(async name => {
     const end = timeProvidersUpload.startTimer({ name });
     const result = await providersMap[name].set(params);
     end();
 
+    const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params))).length;
+    providersUploadSize.inc({ name }, size);
     return result;
   });
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,6 +3,7 @@ import * as infura from './infura';
 import * as pinata from './pinata';
 import * as web3Storage from './web3storage';
 import * as fourEverland from './4everland';
+import { timeProvidersUpload } from '../metrics';
 
 // List of providers used for pinning images
 export const IMAGE_PROVIDERS = ['fleek', 'infura', 'pinata', '4everland'];
@@ -17,7 +18,11 @@ const providersMap = {
 };
 
 export default function set(providers: string[], params?: any) {
-  return providers.map(name => {
-    return providersMap[name].set(params);
+  return providers.map(async name => {
+    const end = timeProvidersUpload.startTimer({ name });
+    const result = await providersMap[name].set(params);
+    end();
+
+    return result;
   });
 }

--- a/src/providers/infura.ts
+++ b/src/providers/infura.ts
@@ -13,13 +13,11 @@ const client = create({
 });
 
 export async function set(data: Buffer | object) {
-  const start = Date.now();
   const input = data instanceof Buffer ? data : JSON.stringify(data);
   const result = await client.add(input, {
     pin: true
   });
   const cid = result.cid.toV0().toString();
-  const ms = Date.now() - start;
 
-  return { cid, provider, ms };
+  return { cid, provider };
 }

--- a/src/providers/pinata.ts
+++ b/src/providers/pinata.ts
@@ -5,8 +5,6 @@ const provider = 'pinata';
 const client = pinataSDK(process.env.PINATA_API_KEY || '', process.env.PINATA_API_SECRET || '');
 
 export async function set(data: Buffer | object) {
-  const start = Date.now();
-
   let result;
   if (data instanceof Buffer) {
     const stream = Readable.from(data);
@@ -18,7 +16,6 @@ export async function set(data: Buffer | object) {
   }
 
   const cid = result.IpfsHash;
-  const ms = Date.now() - start;
 
-  return { cid, provider, ms };
+  return { cid, provider };
 }

--- a/src/providers/web3storage.ts
+++ b/src/providers/web3storage.ts
@@ -5,8 +5,6 @@ const provider = 'web3storage';
 const client = new Web3Storage({ token: process.env.WEB3STORAGE_API_TOKEN || '' });
 
 export async function set(data: Buffer | object) {
-  const start = Date.now();
-
   let file;
   if (data instanceof Buffer) {
     const blob = new Blob([data]);
@@ -18,7 +16,6 @@ export async function set(data: Buffer | object) {
   }
 
   const cid = await client.put([file], { wrapWithDirectory: false });
-  const ms = Date.now() - start;
 
-  return { cid, provider, ms };
+  return { cid, provider };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,7 +5,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import gateways from './gateways.json';
 import { set, get } from './aws';
 import { MAX, sha256 } from './utils';
-import { timeIpfsGatewaysResponse } from './metrics';
+import { ipfsGatewaysReturnCount, timeIpfsGatewaysResponse } from './metrics';
 
 const router = express.Router();
 
@@ -14,18 +14,26 @@ router.get('/ipfs/*', async (req, res) => {
   try {
     const cache = await get(`cache/${key}`);
     if (cache) return res.json(cache);
-    const json = await Promise.any(
+
+    const result = await Promise.any(
       gateways.map(async gateway => {
         const end = timeIpfsGatewaysResponse.startTimer({ name: gateway });
         const url = `https://${gateway}${req.originalUrl}`;
-        await fetch(url);
+        const response = await fetch(url);
         end();
-        return res.json();
+        return { gateway, json: await response.json() };
       })
     );
-    res.json(json);
-    const size = Buffer.from(JSON.stringify(json)).length;
-    if (size <= MAX) await set(`cache/${key}`, json);
+    ipfsGatewaysReturnCount.inc({ name: result.gateway });
+
+    try {
+      const size = Buffer.from(JSON.stringify(result.json)).length;
+      if (size <= MAX) await set(`cache/${key}`, result.json);
+    } catch (e) {
+      capture(e);
+    }
+
+    return res.json(result.json);
   } catch (e) {
     capture(e);
     return res.status(500).json();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 import fetch from 'cross-fetch';
 import Promise from 'bluebird';
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import gateways from './gateways.json';
 import { set, get } from './aws';
 import { MAX, sha256 } from './utils';
-import { capture } from '@snapshot-labs/snapshot-sentry';
+import { timeIpfsGatewaysResponse } from './metrics';
 
 const router = express.Router();
 
@@ -14,9 +15,12 @@ router.get('/ipfs/*', async (req, res) => {
     const cache = await get(`cache/${key}`);
     if (cache) return res.json(cache);
     const json = await Promise.any(
-      gateways.map(gateway => {
+      gateways.map(async gateway => {
+        const end = timeIpfsGatewaysResponse.startTimer({ name: gateway });
         const url = `https://${gateway}${req.originalUrl}`;
-        return fetch(url).then(res => res.json());
+        await fetch(url);
+        end();
+        return res.json();
       })
     );
     res.json(json);

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -3,7 +3,6 @@ import Promise from 'bluebird';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { MAX, rpcError, rpcSuccess } from './utils';
 import { set as setAws } from './aws';
-import { stats } from './stats';
 import { JSON_PROVIDERS, default as set } from './providers/';
 
 const router = express.Router();
@@ -15,8 +14,6 @@ router.post('/', async (req, res) => {
     if (size > MAX) return rpcError(res, 400, 'File too large', id);
     const result = await Promise.any(set(JSON_PROVIDERS, params));
     await setAws(result.cid, params);
-    stats.providers[result.provider] = (stats.providers[result.provider] || 0) + 1;
-    stats.total += 1;
     console.log('Success', result.provider, 'size', size, 'ms', result.ms);
     result.size = size;
     return rpcSuccess(res, result, id);

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,4 +1,0 @@
-export const stats = {
-  total: 0,
-  providers: {}
-};

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -6,6 +6,7 @@ import sharp from 'sharp';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { rpcError, rpcSuccess } from './utils';
 import { IMAGE_PROVIDERS, default as set } from './providers/';
+import { providersInstrumentation } from './metrics';
 
 const MAX_INPUT_SIZE = 1024 * 1024;
 const MAX_IMAGE_DIMENSION = 1500;
@@ -16,7 +17,7 @@ const upload = multer({
   limits: { fileSize: MAX_INPUT_SIZE }
 }).single('file');
 
-router.post('/upload', async (req, res) => {
+router.post('/upload', providersInstrumentation, async (req, res) => {
   upload(req, res, async err => {
     try {
       if (err) return rpcError(res, 400, err.message);
@@ -41,6 +42,7 @@ router.post('/upload', async (req, res) => {
         provider: result.provider
       };
       console.log('Upload success', result.provider, result.cid);
+
       return rpcSuccess(res, file);
     } catch (e: any) {
       if (e.message === 'Input buffer contains unsupported image format') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1786,6 +1786,14 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
+"@snapshot-labs/snapshot-metrics@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-metrics/-/snapshot-metrics-1.0.0.tgz#1f88a6aacc81f639f7059c153b53c550934cd3b3"
+  integrity sha512-6T8a2NX6Qo6zVAoNIWV8eSJCukCynI/HCLp37VZTzX8jwU/ahGsiDTQC3I/MDus+LDB+8pI5nju33NwM8Q7n2g==
+  dependencies:
+    express-prom-bundle "^6.6.0"
+    prom-client "^14.2.0"
+
 "@snapshot-labs/snapshot-sentry@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-1.1.0.tgz#b357d4789ffd287f90fb70e7f0b207b47627cf24"
@@ -2474,6 +2482,11 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
 bl@^4.0.3:
   version "4.1.0"
@@ -3539,6 +3552,14 @@ expect@^28.1.0:
     jest-matcher-utils "^28.1.0"
     jest-message-util "^28.1.0"
     jest-util "^28.1.0"
+
+express-prom-bundle@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/express-prom-bundle/-/express-prom-bundle-6.6.0.tgz#9c33c1bd1478d70e3961a53aed2d17f15ef821ca"
+  integrity sha512-tZh2P2p5a8/yxQ5VbRav011Poa4R0mHqdFwn9Swe/obXDe5F0jY9wtRAfNYnqk4LXY7akyvR/nrvAHxQPWUjsQ==
+  dependencies:
+    on-finished "^2.3.0"
+    url-value-parser "^2.0.0"
 
 express@^4.18.2:
   version "4.18.2"
@@ -5903,7 +5924,7 @@ object.assign@^4.1.2:
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
-on-finished@2.4.1:
+on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -6171,6 +6192,13 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
+  dependencies:
+    tdigest "^0.1.1"
 
 prompts@^2.0.1:
   version "2.4.2"
@@ -6998,6 +7026,13 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
+
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -7290,6 +7325,11 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
+
+url-value-parser@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/url-value-parser/-/url-value-parser-2.2.0.tgz#f38ae8cd24604ec69bc219d66929ddbbd93a2b32"
+  integrity sha512-yIQdxJpgkPamPPAPuGdS7Q548rLhny42tg8d4vyTNzFqvOnwqrgHXvgehT09U7fwrzxi3RxCiXjoNUNnNOlQ8A==
 
 url@0.10.3:
   version "0.10.3"


### PR DESCRIPTION
This PR install the metrics system

- Install the basic @snapshot-labs/snapshot-metrics package
- Instrument each providers response time, upload size and number of uses
- Instrument each gateway response time and number of uses
- Remove redundant timer inside each provider
- Remove dependabot
- Remove the `stats` global variable (not needed anymore, since we can track the same data from dashboard, and they're not reset on each restart)

Requires #146 

Fixes PINEAPPLE-4

## Tests 

### Default metrics 

- Visit `http://localhost:3003/metrics`
- It should show the basic metrics

### Providers metrics

- Upload one image/json
- Visit the metrics endpoint again
- It should show the custom metrics for providers (`providers_upload_duration_seconds` , `providers_upload_size` and `providers_return_count`)

### Gateways metrics

- Visit `http://localhost:3003/ipfs/bafkreib5epjzumf3omr7rth5mtcsz4ugcoh3ut4d46hx5xhwm4b3pqr2vi`
- Visit the metrics endpoint again
- It should show the custom metrics for gateway (`ipfs_gateways_response_duration_seconds` and `ipfs_gateways_return_count`)