### PR TITLE
fix: catch and return 400 error when payload is invalid

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -13,6 +13,11 @@ const router = express.Router();
 
 router.post('/', async (req, res) => {
   const { id, params } = req.body;
+
+  if (!params) {
+    return rpcError(res, 400, 'Malformed body', id);
+  }
+
   try {
     const size = Buffer.from(JSON.stringify(params)).length;
     if (size > MAX) return rpcError(res, 400, 'File too large', id);
@@ -22,7 +27,11 @@ router.post('/', async (req, res) => {
       setWeb3Storage(params),
       set4everland(params)
     ]);
-    await setAws(result.cid, params);
+    try {
+      await setAws(result.cid, params);
+    } catch (e: any) {
+      capture(e);
+    }
     stats.providers[result.provider] = (stats.providers[result.provider] || 0) + 1;
     stats.total += 1;
     console.log('Success', result.provider, 'size', size, 'ms', result.ms);

--- a/test/e2e/rpc.test.ts
+++ b/test/e2e/rpc.test.ts
@@ -1,0 +1,33 @@
+import request from 'supertest';
+
+const HOST = `http://localhost:${process.env.PORT || 3003}`;
+
+describe('POST /', () => {
+  describe('when the payload is valid', () => {
+    it('returns a 200 error', async () => {
+      const response = await request(HOST)
+        .post('/')
+        .send({ params: { test: 'value' } });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.result.cid.length).toBeGreaterThan(10);
+      expect(['4everland', 'infura', 'fleek', 'pinata']).toContain(response.body.result.provider);
+    });
+  });
+
+  describe('when the payload is no valid', () => {
+    it('returns a 400 error on malformed json', async () => {
+      const response = await request(HOST).post('/').send({ test: 'value' });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.error.message).toBe('Malformed body');
+    });
+
+    it('returns a 400 error on empty body', async () => {
+      const response = await request(HOST).post('/');
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body.error.message).toBe('Malformed body');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #150 
Fixes PINEAPPLE-5 

Fix error when the post body is malformed (missing the `params` key)

- Also try/catch the AWS cache function, so it fail transparently when the credentials are not set
- Add test for the JSON upload enpdoint