### PR TITLE
fix: instrument the number of open outgoing connections

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -47,6 +47,18 @@ export const ipfsGatewaysReturnCount = new client.Counter({
   labelNames: ['name']
 });
 
+export const countOpenProvidersRequest = new client.Gauge({
+  name: 'providers_open_connections_count',
+  help: 'Number of open connections to providers',
+  labelNames: ['name']
+});
+
+export const countOpenGatewaysRequest = new client.Gauge({
+  name: 'ipfs_gateways_open_connections_count',
+  help: 'Number of open connections to gateways',
+  labelNames: ['name']
+});
+
 export const providersInstrumentation = (req, res, next) => {
   const oldJson = res.json;
   res.json = body => {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -21,14 +21,20 @@ export default function uploadToProviders(providers: string[], params: any) {
   return Promise.any(
     providers.map(async name => {
       const end = timeProvidersUpload.startTimer({ name });
-      countOpenProvidersRequest.inc({ name });
-      const result = await providersMap[name].set(params);
-      end();
 
-      const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params))).length;
-      providersUploadSize.inc({ name }, size);
-      countOpenProvidersRequest.dec({ name });
-      return result;
+      try {
+        countOpenProvidersRequest.inc({ name });
+
+        const result = await providersMap[name].set(params);
+        const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params)))
+          .length;
+        providersUploadSize.inc({ name }, size);
+
+        return result;
+      } finally {
+        end();
+        countOpenProvidersRequest.dec({ name });
+      }
     })
   );
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,9 +1,9 @@
+import { timeProvidersUpload, providersUploadSize, countOpenProvidersRequest } from '../metrics';
 import * as fleek from './fleek';
 import * as infura from './infura';
 import * as pinata from './pinata';
 import * as web3Storage from './web3storage';
 import * as fourEverland from './4everland';
-import { timeProvidersUpload, providersUploadSize } from '../metrics';
 
 // List of providers used for pinning images
 export const IMAGE_PROVIDERS = ['fleek', 'infura', 'pinata', '4everland'];
@@ -21,11 +21,13 @@ export default function uploadToProviders(providers: string[], params: any) {
   return Promise.any(
     providers.map(async name => {
       const end = timeProvidersUpload.startTimer({ name });
+      countOpenProvidersRequest.inc({ name });
       const result = await providersMap[name].set(params);
       end();
 
       const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params))).length;
       providersUploadSize.inc({ name }, size);
+      countOpenProvidersRequest.dec({ name });
       return result;
     })
   );

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,7 +5,11 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import gateways from './gateways.json';
 import { set, get } from './aws';
 import { MAX, sha256 } from './utils';
-import { ipfsGatewaysReturnCount, timeIpfsGatewaysResponse } from './metrics';
+import {
+  ipfsGatewaysReturnCount,
+  timeIpfsGatewaysResponse,
+  countOpenGatewaysRequest
+} from './metrics';
 
 const router = express.Router();
 
@@ -18,9 +22,11 @@ router.get('/ipfs/*', async (req, res) => {
     const result = await Promise.any(
       gateways.map(async gateway => {
         const end = timeIpfsGatewaysResponse.startTimer({ name: gateway });
+        countOpenGatewaysRequest.inc({ name: gateway });
         const url = `https://${gateway}${req.originalUrl}`;
         const response = await fetch(url);
         end();
+        countOpenGatewaysRequest.dec({ name: gateway });
         return { gateway, json: await response.json() };
       })
     );

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,12 +22,18 @@ router.get('/ipfs/*', async (req, res) => {
     const result = await Promise.any(
       gateways.map(async gateway => {
         const end = timeIpfsGatewaysResponse.startTimer({ name: gateway });
-        countOpenGatewaysRequest.inc({ name: gateway });
-        const url = `https://${gateway}${req.originalUrl}`;
-        const response = await fetch(url);
-        end();
-        countOpenGatewaysRequest.dec({ name: gateway });
-        return { gateway, json: await response.json() };
+
+        try {
+          countOpenGatewaysRequest.inc({ name: gateway });
+
+          const url = `https://${gateway}${req.originalUrl}`;
+          const response = await fetch(url);
+
+          return { gateway, json: await response.json() };
+        } finally {
+          end();
+          countOpenGatewaysRequest.dec({ name: gateway });
+        }
       })
     );
     ipfsGatewaysReturnCount.inc({ name: result.gateway });


### PR DESCRIPTION
This PR adds 2 new gauges to monitor the number of outgoing open connections, triggered by async requests.

Trying to debug, and confirm whether the current memory leaks issue is coming from async outgoing requests 