### PR TITLE
chore: add dependabot for orgs only package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      # Allow updates for snapshot.js only
+      - dependency-name: "@snapshot-labs/*"


### PR DESCRIPTION
This PR add back dependabot, but only enable it for package published by @snapshot-labs