### PR TITLE
fix: add timeout to infura upload

### DIFF
--- a/src/providers/infura.ts
+++ b/src/providers/infura.ts
@@ -7,6 +7,7 @@ const client = create({
   host: 'ipfs.infura.io',
   port: 5001,
   protocol: 'https',
+  timeout: 10e3,
   headers: {
     authorization: `Basic ${Buffer.from(`${INFURA_PROJECT_ID}:${INFURA_PROJECT_SECRET}`).toString(
       'base64'


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

For unknown reasons, the Infura provider stop returning responses in a timely manner

![Screenshot 2023-09-01 at 17 13 43](https://github.com/snapshot-labs/pineapple/assets/495709/af78ca86-2b89-476c-b6a8-4150268c3eb3)

The upload time keep increasing, and queries keep getting queued, until the process hit an out-of-memory error, and restart.

![Screenshot 2023-09-01 at 17 20 14](https://github.com/snapshot-labs/pineapple/assets/495709/d50f0e19-d759-4d41-9c27-a8b275458d19)

After the restart, Infura does not have any issues, despite receiving more traffic than before the restart.

## 💊 Fixes / Solution

Fix #164 
Fix [SNAPSHOT-SEQUENCER-H](https://snapshot-labs.sentry.io/issues/4415715774/?referrer=github_integration)

Add a `timeout` of 10s to infura upload. Average upload time is between 3s and 4s.

## 🚧 Changes

- Add 10s timeout to infura

## 🛠️ Tests

- N/A