### PR TITLE
chore: instrument count of active providers per type

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -48,7 +48,7 @@ export const timeProvidersUpload = new client.Histogram({
 export const providersUploadSize = new client.Counter({
   name: 'providers_upload_size',
   help: "Total size of each provider's upload file.",
-  labelNames: ['name']
+  labelNames: ['name', 'type']
 });
 
 const providersReturnCount = new client.Counter({

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -22,7 +22,7 @@ export default function initMetrics(app: Express) {
 
 const gatewaysCount = new client.Gauge({
   name: 'ipfs_gateways_count',
-  help: 'Number of IPFS gateways'
+  help: 'Number of IPFS gateways.'
 });
 gatewaysCount.set(gateways.length);
 
@@ -40,45 +40,45 @@ providersImageCount.set(IMAGE_PROVIDERS.filter(p => providersMap[p].isConfigured
 
 export const timeProvidersUpload = new client.Histogram({
   name: 'providers_upload_duration_seconds',
-  help: "Duration in seconds of provider's upload requests",
+  help: "Duration in seconds of provider's upload requests.",
   labelNames: ['name'],
   buckets: [0.5, 1, 2, 5, 10, 15]
 });
 
 export const providersUploadSize = new client.Counter({
   name: 'providers_upload_size',
-  help: "Total size of each provider's upload file",
+  help: "Total size of each provider's upload file.",
   labelNames: ['name']
 });
 
 const providersReturnCount = new client.Counter({
   name: 'providers_return_count',
-  help: 'Number of times each provider have been used',
+  help: 'Number of times each provider have been used.',
   labelNames: ['name']
 });
 
 export const timeIpfsGatewaysResponse = new client.Histogram({
   name: 'ipfs_gateways_response_duration_seconds',
-  help: "Duration in seconds of each IPFS gateway's reponse",
+  help: "Duration in seconds of each IPFS gateway's reponse.",
   labelNames: ['name'],
   buckets: [0.5, 1, 2, 5, 10, 15]
 });
 
 export const ipfsGatewaysReturnCount = new client.Counter({
   name: 'ipfs_gateways_return_count',
-  help: 'Number of times each gateway have been used',
+  help: 'Number of times each gateway have been used.',
   labelNames: ['name']
 });
 
 export const countOpenProvidersRequest = new client.Gauge({
   name: 'providers_open_connections_count',
-  help: 'Number of open connections to providers',
+  help: 'Number of open connections to providers.',
   labelNames: ['name']
 });
 
 export const countOpenGatewaysRequest = new client.Gauge({
   name: 'ipfs_gateways_open_connections_count',
-  help: 'Number of open connections to gateways',
+  help: 'Number of open connections to gateways.',
   labelNames: ['name']
 });
 
@@ -97,7 +97,7 @@ export const providersInstrumentation = (req, res, next) => {
 
 new client.Gauge({
   name: 'express_open_connections_size',
-  help: 'Number of open connections on the express server',
+  help: 'Number of open connections on the express server.',
   async collect() {
     if (server) {
       this.set(server._connections);

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -41,7 +41,7 @@ providersImageCount.set(IMAGE_PROVIDERS.filter(p => providersMap[p].isConfigured
 export const timeProvidersUpload = new client.Histogram({
   name: 'providers_upload_duration_seconds',
   help: "Duration in seconds of provider's upload requests.",
-  labelNames: ['name'],
+  labelNames: ['name', 'type'],
   buckets: [0.5, 1, 2, 5, 10, 15]
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,6 +1,7 @@
 import init, { client } from '@snapshot-labs/snapshot-metrics';
 import type { Express } from 'express';
 import gateways from './gateways.json';
+import { providersMap, IMAGE_PROVIDERS, JSON_PROVIDERS } from './providers/utils';
 
 let server;
 
@@ -24,6 +25,18 @@ const gatewaysCount = new client.Gauge({
   help: 'Number of IPFS gateways'
 });
 gatewaysCount.set(gateways.length);
+
+const providersJsonCount = new client.Gauge({
+  name: 'providers_json_count',
+  help: 'Number of providers used for JSON pinning.'
+});
+providersJsonCount.set(JSON_PROVIDERS.filter(p => providersMap[p].isConfigured()).length);
+
+const providersImageCount = new client.Gauge({
+  name: 'providers_image_count',
+  help: 'Number of providers used for image pinning.'
+});
+providersImageCount.set(IMAGE_PROVIDERS.filter(p => providersMap[p].isConfigured()).length);
 
 export const timeProvidersUpload = new client.Histogram({
   name: 'providers_upload_duration_seconds',

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -14,7 +14,8 @@ export default function uploadToProviders(providers: string[], params: any) {
         const result = await providersMap[name].set(params);
         const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params)))
           .length;
-        providersUploadSize.inc({ name }, size);
+        const type = params instanceof Buffer ? 'image' : 'json';
+        providersUploadSize.inc({ name, type }, size);
 
         return result;
       } finally {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -6,7 +6,8 @@ export default function uploadToProviders(providers: string[], params: any) {
 
   return Promise.any(
     configuredProviders.map(async name => {
-      const end = timeProvidersUpload.startTimer({ name });
+      const type = params instanceof Buffer ? 'image' : 'json';
+      const end = timeProvidersUpload.startTimer({ name, type });
 
       try {
         countOpenProvidersRequest.inc({ name });
@@ -14,7 +15,6 @@ export default function uploadToProviders(providers: string[], params: any) {
         const result = await providersMap[name].set(params);
         const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params)))
           .length;
-        const type = params instanceof Buffer ? 'image' : 'json';
         providersUploadSize.inc({ name, type }, size);
 
         return result;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,21 +1,5 @@
 import { timeProvidersUpload, providersUploadSize, countOpenProvidersRequest } from '../metrics';
-import * as fleek from './fleek';
-import * as infura from './infura';
-import * as pinata from './pinata';
-import * as web3Storage from './web3storage';
-import * as fourEverland from './4everland';
-
-// List of providers used for pinning images
-export const IMAGE_PROVIDERS = ['fleek', 'infura', 'pinata', '4everland'];
-// List of providers used for pinning json
-export const JSON_PROVIDERS = ['fleek', 'infura', 'web3storage', '4everland'];
-const providersMap = {
-  fleek,
-  infura,
-  pinata,
-  web3Storage,
-  '4everland': fourEverland
-};
+import { providersMap } from './utils';
 
 export default function uploadToProviders(providers: string[], params: any) {
   return Promise.any(

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,0 +1,19 @@
+import * as fleek from './fleek';
+import * as infura from './infura';
+import * as pinata from './pinata';
+import * as web3storage from './web3storage';
+import * as fourEverland from './4everland';
+
+// List of providers used for pinning images
+export const IMAGE_PROVIDERS = ['fleek', 'infura', 'pinata', '4everland'];
+
+// List of providers used for pinning json
+export const JSON_PROVIDERS = ['fleek', 'infura', 'web3storage', '4everland'];
+
+export const providersMap = {
+  fleek,
+  infura,
+  pinata,
+  web3storage,
+  '4everland': fourEverland
+};

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -2,7 +2,8 @@ import express from 'express';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { MAX, rpcError, rpcSuccess } from './utils';
 import { set as setAws } from './aws';
-import uploadToProviders, { JSON_PROVIDERS } from './providers/';
+import uploadToProviders from './providers/';
+import { JSON_PROVIDERS } from './providers/utils';
 import { providersInstrumentation } from './metrics';
 
 const router = express.Router();

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -4,7 +4,8 @@ import multer from 'multer';
 import sharp from 'sharp';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { rpcError, rpcSuccess } from './utils';
-import uploadToProviders, { IMAGE_PROVIDERS } from './providers/';
+import uploadToProviders from './providers/';
+import { IMAGE_PROVIDERS } from './providers/utils';
 import { providersInstrumentation } from './metrics';
 
 const MAX_INPUT_SIZE = 1024 * 1024;


### PR DESCRIPTION
This PR instrument the number of active providers per upload type (image/json)

## Other minor fixes/changes

- Move some code to `providers/utils.ts`: to avoid import loop
- End all metric HELP with a dot (`.`): follow best practice
- Add `type` (image/json) to `providers_upload_size` metrics
- Add `type` (image/json) to `providers_upload_duration_seconds` metrics