### PR TITLE
fix: skip disabled providers

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,7 +2,7 @@ import { timeProvidersUpload, providersUploadSize, countOpenProvidersRequest } f
 import * as fleek from './fleek';
 import * as infura from './infura';
 import * as pinata from './pinata';
-import * as web3Storage from './web3storage';
+import * as web3storage from './web3storage';
 import * as fourEverland from './4everland';
 
 // List of providers used for pinning images
@@ -13,13 +13,15 @@ const providersMap = {
   fleek,
   infura,
   pinata,
-  web3Storage,
+  web3storage,
   '4everland': fourEverland
 };
 
 export default function uploadToProviders(providers: string[], params: any) {
+  const configuredProviders = providers.filter(p => providersMap[p].isConfigured());
+
   return Promise.any(
-    providers.map(async name => {
+    configuredProviders.map(async name => {
       const end = timeProvidersUpload.startTimer({ name });
 
       try {


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The `uploadToProviders` process all providers passed to it. That list is a constant, and does not take into account providers that were disabled because of missing credentials.

## 💊 Fixes / Solution

Skip providers that were not configured (missing credentials from .env)

## 🚧 Changes

- Add a filter to only process providers properly configured
- Fix web3Storage provider name casing

## 🛠️ Tests

