### PR TITLE
chore: add provider type to all providers metrics

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,17 +1,18 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { timeProvidersUpload, providersUploadSize, countOpenProvidersRequest } from '../metrics';
 import { providersMap } from './utils';
+type ProviderType = 'image' | 'json';
 
-export default function uploadToProviders(providers: string[], params: any) {
+export default function uploadToProviders(providers: string[], type: ProviderType, params: any) {
   const configuredProviders = providers.filter(p => providersMap[p].isConfigured());
 
   return Promise.any(
     configuredProviders.map(async name => {
-      const type = params instanceof Buffer ? 'image' : 'json';
+      const type: ProviderType = params instanceof Buffer ? 'image' : 'json';
       const end = timeProvidersUpload.startTimer({ name, type });
 
       try {
-        countOpenProvidersRequest.inc({ name });
+        countOpenProvidersRequest.inc({ name, type });
 
         const result = await providersMap[name].set(params);
         const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params)))
@@ -24,7 +25,7 @@ export default function uploadToProviders(providers: string[], params: any) {
         throw e;
       } finally {
         end();
-        countOpenProvidersRequest.dec({ name });
+        countOpenProvidersRequest.dec({ name, type });
       }
     })
   );

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -4,11 +4,10 @@ import { MAX, rpcError, rpcSuccess } from './utils';
 import { set as setAws } from './aws';
 import uploadToProviders from './providers/';
 import { JSON_PROVIDERS } from './providers/utils';
-import { providersInstrumentation } from './metrics';
 
 const router = express.Router();
 
-router.post('/', providersInstrumentation, async (req, res) => {
+router.post('/', async (req, res) => {
   const { id, params } = req.body;
 
   if (!params) {
@@ -19,7 +18,7 @@ router.post('/', providersInstrumentation, async (req, res) => {
     const size = Buffer.from(JSON.stringify(params)).length;
     if (size > MAX) return rpcError(res, 400, 'File too large', id);
 
-    const result = await uploadToProviders(JSON_PROVIDERS, params);
+    const result = await uploadToProviders(JSON_PROVIDERS, 'json', params);
     try {
       await setAws(result.cid, params);
     } catch (e: any) {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -6,7 +6,6 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import { rpcError, rpcSuccess } from './utils';
 import uploadToProviders from './providers/';
 import { IMAGE_PROVIDERS } from './providers/utils';
-import { providersInstrumentation } from './metrics';
 
 const MAX_INPUT_SIZE = 1024 * 1024;
 const MAX_IMAGE_DIMENSION = 1500;
@@ -17,7 +16,7 @@ const upload = multer({
   limits: { fileSize: MAX_INPUT_SIZE }
 }).single('file');
 
-router.post('/upload', providersInstrumentation, async (req, res) => {
+router.post('/upload', async (req, res) => {
   upload(req, res, async err => {
     try {
       if (err) return rpcError(res, 400, err.message);
@@ -36,7 +35,7 @@ router.post('/upload', providersInstrumentation, async (req, res) => {
         .pipe(transformer)
         .toBuffer();
 
-      const result = await uploadToProviders(IMAGE_PROVIDERS, buffer);
+      const result = await uploadToProviders(IMAGE_PROVIDERS, 'image', buffer);
       const file = {
         cid: result.cid,
         provider: result.provider


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Some provider metrics are not labeled by type (json/image). 

## 💊 Fixes / Solution

- Add the `type` label to remaining providers metrics without it 

## 🚧 Changes

- Add `type` label to all remaining providers metrics without it 
- Migrate the `providersInstrumentation` middleware declaration inside metrics.ts. Inside of using of declaring the middleware usage next to each router, we move it inside the metrics.ts file, and use a kind of hook system to attach it to the correct route. This will reduce the metrics code footprint, instrumentation code should the most unobtrusive possible.

## 🛠️ Tests

- Upload some JSON and image (via postman or other way)
- Visit `http://localhost:3000/metrics`
- The `providers_return_count` metric should have a new `type` label value, with value either `image` of `json`
