### PR TITLE
fix: fix finally block not executed

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -41,7 +41,7 @@ providersImageCount.set(IMAGE_PROVIDERS.filter(p => providersMap[p].isConfigured
 export const timeProvidersUpload = new client.Histogram({
   name: 'providers_upload_duration_seconds',
   help: "Duration in seconds of provider's upload requests.",
-  labelNames: ['name', 'type'],
+  labelNames: ['name', 'type', 'status'],
   buckets: [0.5, 1, 2, 5, 10, 15]
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -60,7 +60,7 @@ const providersReturnCount = new client.Counter({
 export const timeIpfsGatewaysResponse = new client.Histogram({
   name: 'ipfs_gateways_response_duration_seconds',
   help: "Duration in seconds of each IPFS gateway's reponse.",
-  labelNames: ['name'],
+  labelNames: ['name', 'status'],
   buckets: [0.5, 1, 2, 5, 10, 15]
 });
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -9,7 +9,7 @@ export default function uploadToProviders(providers: string[], params: any) {
     configuredProviders.map(async name => {
       const type = params instanceof Buffer ? 'image' : 'json';
       const end = timeProvidersUpload.startTimer({ name, type });
-      let success = false;
+      let status = 0;
 
       try {
         countOpenProvidersRequest.inc({ name });
@@ -18,14 +18,14 @@ export default function uploadToProviders(providers: string[], params: any) {
         const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params)))
           .length;
         providersUploadSize.inc({ name, type }, size);
-        success = true;
+        status = 1;
 
         return result;
       } catch (e: any) {
         capture(e, { name });
         return Promise.reject(e);
       } finally {
-        end({ status: +success });
+        end({ status });
         countOpenProvidersRequest.dec({ name });
       }
     })

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -23,7 +23,11 @@ export default function uploadToProviders(providers: string[], type: ProviderTyp
 
         return result;
       } catch (e: any) {
-        capture(e, { name });
+        if (e instanceof Error) {
+          capture(e, { name });
+        } else {
+          capture('Error from provider', { contexts: { input: { name }, provider_response: e } });
+        }
         return Promise.reject(e);
       } finally {
         end({ status });

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -9,6 +9,7 @@ export default function uploadToProviders(providers: string[], params: any) {
     configuredProviders.map(async name => {
       const type = params instanceof Buffer ? 'image' : 'json';
       const end = timeProvidersUpload.startTimer({ name, type });
+      let success = false;
 
       try {
         countOpenProvidersRequest.inc({ name });
@@ -17,13 +18,14 @@ export default function uploadToProviders(providers: string[], params: any) {
         const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params)))
           .length;
         providersUploadSize.inc({ name, type }, size);
+        success = true;
 
         return result;
       } catch (e: any) {
         capture(e, { name });
         return Promise.reject(e);
       } finally {
-        end();
+        end({ status: +success });
         countOpenProvidersRequest.dec({ name });
       }
     })

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -21,7 +21,7 @@ export default function uploadToProviders(providers: string[], params: any) {
         return result;
       } catch (e: any) {
         capture(e, { name });
-        throw e;
+        return Promise.reject(e);
       } finally {
         end();
         countOpenProvidersRequest.dec({ name });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,6 +21,7 @@ router.get('/ipfs/*', async (req, res) => {
     const result = await Promise.any(
       gateways.map(async gateway => {
         const end = timeIpfsGatewaysResponse.startTimer({ name: gateway });
+        let status = 0;
 
         try {
           countOpenGatewaysRequest.inc({ name: gateway });
@@ -31,10 +32,11 @@ router.get('/ipfs/*', async (req, res) => {
           if (!response.ok) {
             return Promise.reject(response.status);
           }
+          status = 1;
 
           return { gateway, json: await response.json() };
         } finally {
-          end();
+          end({ status });
           countOpenGatewaysRequest.dec({ name: gateway });
         }
       })


### PR DESCRIPTION
## Fix

Fix the `finally` not being executed due to error thrown inside catch block. Fixed by returning  a `Promise.reject` instead

## Chores

- Add `status` label to `ipfs_gateways_response_duration_seconds` and `providers_upload_duration_seconds` metrics => differentiate metrics for requests that succeed/failed
- When the error is a well formatted JSON response, send it to Sentry as contexts => avoid error type `Non-Error exception captured with keys: details, reason`