### PR TITLE
chore: send error object to Sentry

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -26,7 +26,9 @@ export default function uploadToProviders(providers: string[], type: ProviderTyp
         if (e instanceof Error) {
           capture(e, { name });
         } else {
-          capture('Error from provider', { contexts: { input: { name }, provider_response: e } });
+          capture(new Error(`Error from ${name} provider`), {
+            contexts: { provider_response: e }
+          });
         }
         return Promise.reject(e);
       } finally {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -25,7 +25,7 @@ export default function uploadToProviders(providers: string[], type: ProviderTyp
       } catch (e: any) {
         if (e instanceof Error) {
           capture(e, { name });
-        } else {
+        } else if (e?.message !== 'Request timed out') {
           capture(new Error(`Error from ${name} provider`), {
             contexts: { provider_response: e }
           });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When capturing and sending a string to sentry, it'll show on Sentry as `<anonymous>` (See example here https://snapshot-labs.sentry.io/issues/4457737309/?project=4505506861023232&query=&referrer=issue-stream&statsPeriod=14d&stream_index=1)

## 💊 Fixes / Solution

Send an error object instead of string

## 🚧 Changes

- Wrap the string into an Error object, so that Sentry can show the correct title
- Avoid logging Timeout error (fix #173 )

## 🛠️ Tests

- N/A