### PR TITLE
fix: IPFS gateway should return only json content

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -32,9 +32,20 @@ router.get('/ipfs/*', async (req, res) => {
           if (!response.ok) {
             return Promise.reject(response.status);
           }
-          status = 1;
 
-          return { gateway, json: await response.json() };
+          if (!['text/plain', 'application/json'].includes(response.headers.get('content-type'))) {
+            return Promise.reject('');
+          }
+
+          let json;
+          try {
+            json = await response.json();
+          } catch {
+            return Promise.reject('');
+          }
+
+          status = 1;
+          return { gateway, json };
         } finally {
           end({ status });
           countOpenGatewaysRequest.dec({ name: gateway });

--- a/test/e2e/proxy.test.ts
+++ b/test/e2e/proxy.test.ts
@@ -4,13 +4,21 @@ const HOST = `http://localhost:${process.env.PORT || 3003}`;
 
 describe('GET /ipfs/*', () => {
   describe('when the IPFS cid exists', () => {
-    it('returns the JSON file', async () => {
+    it('returns a JSON file', async () => {
       const response = await request(HOST).get(
         '/ipfs/bafkreib5epjzumf3omr7rth5mtcsz4ugcoh3ut4d46hx5xhwm4b3pqr2vi'
       );
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toEqual({ status: 'OK' });
+    });
+
+    it('returns a 400 error when not a JSON file', async () => {
+      const response = await request(HOST).get(
+        '/ipfs/bafybeie2x4ptheqskiauhfz4w4pbq7o6742oupitganczhjanvffp2spti'
+      );
+
+      expect(response.statusCode).toBe(400);
     });
   });
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The `/ipfs/*` endpoint is currently returning json content. 

But when the given CID is something else than a JSON file, the endpoint fail, with a timeout error (`await response.json()` is timing out)

## 💊 Fixes / Solution

- Return a 400 error when the content-type is not a json file

## 🚧 Changes

- reject the promise when the content-type is not matching a json content type
- reject the promise when parsing the body as json is failing.

## 🛠️ Tests

- Run the tests
- http://localhost:3000/ipfs/bafkreib5epjzumf3omr7rth5mtcsz4ugcoh3ut4d46hx5xhwm4b3pqr2vi should return a json content
- http://localhost:3000/ipfs/bafybeie2x4ptheqskiauhfz4w4pbq7o6742oupitganczhjanvffp2spti should return a 400 error