### PR TITLE
chore: remove verbose logs

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -40,7 +40,6 @@ router.post('/upload', async (req, res) => {
         cid: result.cid,
         provider: result.provider
       };
-      console.log('Upload success', result.provider, result.cid);
 
       return rpcSuccess(res, file);
     } catch (e: any) {


### PR DESCRIPTION
Following https://discord.com/channels/955773041898573854/1147615869908828180/1147830092869935157

Verbose logs should be removed, as not providing much more insight than the dashboard, and just creating noise preventing finding errors from the logs