### PR TITLE
fix: fix wrong cache key when caching json on pin

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,10 +12,10 @@ import {
 
 const router = express.Router();
 
-router.get('^/ipfs/:key([0-9a-zA-Z]+)$', async (req, res) => {
-  const { key } = req.params;
+router.get('^/ipfs/:cid([0-9a-zA-Z]+)$', async (req, res) => {
+  const { cid } = req.params;
   try {
-    const cache = await get(key);
+    const cache = await get(cid);
     if (cache) return res.json(cache);
 
     const result = await Promise.any(
@@ -56,7 +56,7 @@ router.get('^/ipfs/:key([0-9a-zA-Z]+)$', async (req, res) => {
 
     try {
       const size = Buffer.from(JSON.stringify(result.json)).length;
-      if (size <= MAX) await set(key, result.json);
+      if (size <= MAX) await set(cid, result.json);
     } catch (e) {
       capture(e);
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,8 +12,8 @@ import {
 
 const router = express.Router();
 
-router.get(/^\/ipfs\/\w+$/, async (req, res) => {
-  const key = req.originalUrl;
+router.get('^/ipfs/:key([0-9a-zA-Z]+)$', async (req, res) => {
+  const { key } = req.params;
   try {
     const cache = await get(key);
     if (cache) return res.json(cache);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import gateways from './gateways.json';
 import { set, get } from './aws';
-import { MAX, sha256 } from './utils';
+import { MAX } from './utils';
 import {
   ipfsGatewaysReturnCount,
   timeIpfsGatewaysResponse,
@@ -12,10 +12,10 @@ import {
 
 const router = express.Router();
 
-router.get('/ipfs/*', async (req, res) => {
-  const key = sha256(req.originalUrl);
+router.get(/^\/ipfs\/\w+$/, async (req, res) => {
+  const key = req.originalUrl;
   try {
-    const cache = await get(`cache/${key}`);
+    const cache = await get(key);
     if (cache) return res.json(cache);
 
     const result = await Promise.any(
@@ -56,7 +56,7 @@ router.get('/ipfs/*', async (req, res) => {
 
     try {
       const size = Buffer.from(JSON.stringify(result.json)).length;
-      if (size <= MAX) await set(`cache/${key}`, result.json);
+      if (size <= MAX) await set(key, result.json);
     } catch (e) {
       capture(e);
     }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { MAX, rpcError, rpcSuccess, sha256 } from './utils';
+import { MAX, rpcError, rpcSuccess } from './utils';
 import { set as setAws } from './aws';
 import uploadToProviders from './providers/';
 import { JSON_PROVIDERS } from './providers/utils';
@@ -20,7 +20,7 @@ router.post('/', async (req, res) => {
 
     const result = await uploadToProviders(JSON_PROVIDERS, 'json', params);
     try {
-      await setAws(`cache/${sha256(result.cid)}`, params);
+      await setAws(result.cid, params);
     } catch (e: any) {
       capture(e);
     }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { MAX, rpcError, rpcSuccess } from './utils';
+import { MAX, rpcError, rpcSuccess, sha256 } from './utils';
 import { set as setAws } from './aws';
 import uploadToProviders from './providers/';
 import { JSON_PROVIDERS } from './providers/utils';
@@ -20,7 +20,7 @@ router.post('/', async (req, res) => {
 
     const result = await uploadToProviders(JSON_PROVIDERS, 'json', params);
     try {
-      await setAws(result.cid, params);
+      await setAws(`cache/${sha256(result.cid)}`, params);
     } catch (e: any) {
       capture(e);
     }


### PR DESCRIPTION
This PR fix the wrong cache key, when trying to cache the JSON at the same time as pinning

The `/ipfs/ID` endpoint is looking for a cache in the `/cache` folder, and expecting a key hashed with sha256