### PR TITLE
chore: upgrade snapshot-metrics to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-s3": "^3.75.0",
     "@fleekhq/fleek-storage-js": "^1.0.21",
     "@pinata/sdk": "^1.1.25",
-    "@snapshot-labs/snapshot-metrics": "^1.1.0",
+    "@snapshot-labs/snapshot-metrics": "^1.3.0",
     "@snapshot-labs/snapshot-sentry": "^1.5.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,12 +1825,13 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/snapshot-metrics@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-metrics/-/snapshot-metrics-1.1.0.tgz#0b700ed50a28400cae7bfa47de9f5a1cc018719a"
-  integrity sha512-KajdSDd7cjQ9pRRYLDMqSd6yTcQ7Ln2/1zrRY5w23vGTSAH/NF0/7XojPYiW+IIdVAa5fV5nrcjFXT1X62XSYA==
+"@snapshot-labs/snapshot-metrics@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-metrics/-/snapshot-metrics-1.3.0.tgz#bd6be102cc051204f24f7977faac379eb2b8be9d"
+  integrity sha512-QK3iG29LbP2aiDIB2p6/f+Ll33DYXJLIbJTycR9kxYzUIkewsMmc/Zg66+scxXHg0F10FXByOBaG3F+yMEemcQ==
   dependencies:
     express-prom-bundle "^6.6.0"
+    node-fetch "^2.7.0"
     prom-client "^14.2.0"
 
 "@snapshot-labs/snapshot-sentry@^1.5.0":
@@ -5831,6 +5832,13 @@ node-fetch@<3, node-fetch@^2.6.1, node-fetch@^2.6.8:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
   integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
Upgrade snapshot-metrics to 1.3.0

Replacing https://github.com/snapshot-labs/pineapple/pull/185 , because tests are failing when PR open by dependabot. Does not seems to detect the env var