### PR TITLE
feat: resolve files from TheGraph IPFS API

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import express from 'express';
+import { create } from 'ipfs-http-client';
 import fetch from 'node-fetch';
 import gateways from './gateways.json';
 import {
@@ -9,13 +10,34 @@ import {
 } from './metrics';
 import useProxyCache from './middlewares/useProxyCache';
 
-const router = express.Router();
 const UNSUPPORTED_FILE_TYPE = 'unsupported file type';
+
+const router = express.Router();
+const graphIpfsClient = create({ url: 'https://api.thegraph.com/ipfs/api/v0' });
+
+async function getFileFromGraphIpfs(cid: string) {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of graphIpfsClient.cat(cid)) {
+    chunks.push(chunk);
+  }
+
+  try {
+    const json = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+
+    return {
+      gateway: 'graph',
+      json
+    };
+  } catch (e) {
+    return Promise.reject(UNSUPPORTED_FILE_TYPE);
+  }
+}
 
 router.get('^/ipfs/:cid([0-9a-zA-Z]+)$', useProxyCache, async (req, res) => {
   try {
-    const result = await Promise.any(
-      gateways.map(async gateway => {
+    const result = await Promise.any([
+      getFileFromGraphIpfs(req.params.cid),
+      ...gateways.map(async gateway => {
         const end = timeIpfsGatewaysResponse.startTimer({ name: gateway });
         let status = 0;
 
@@ -47,7 +69,7 @@ router.get('^/ipfs/:cid([0-9a-zA-Z]+)$', useProxyCache, async (req, res) => {
           countOpenGatewaysRequest.dec({ name: gateway });
         }
       })
-    );
+    ]);
     ipfsGatewaysReturnCount.inc({ name: result.gateway });
 
     return res.json(result.json);


### PR DESCRIPTION
We use TheGraph IPFS for EVM indexing, because other IPFS services are not resolving well with Subgraphs.

This however becomes a problem, because TheGraph doesn't have public API, so:
1. Trying to access proposal/vote metadata through browser (via View metadata) might not work.
2. Migrating from subgraph to other indexer (Checkpoint) is problematic, because we might not be able to access old data.

We can however access files from TheGraph's IFPS via API.

Right now TheGraph will be called every time we try to access any file via Pineapple. Should it be conditional (via `graphipfs=true` in query params? In that case we would need to update our Checkpoint indexer to include that flag and on UI also add it when trying to view metadata for EVM entities.

## Test plan:
1. This doesn't resolve: https://pineapple.fyi/ipfs/Qmcmw86HDoFJfBc2MHkF1iqjKpaZEuSzApmTNHtVFx3h5M
2. This does: http://localhost:3000/ipfs/Qmcmw86HDoFJfBc2MHkF1iqjKpaZEuSzApmTNHtVFx3h5M