### PR TITLE
fix: catch malformed multipart parse errors so they don't crash the server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,32 @@
 import 'dotenv/config';
-import { fallbackLogger, initLogger } from '@snapshot-labs/snapshot-sentry';
+import { capture, fallbackLogger, initLogger } from '@snapshot-labs/snapshot-sentry';
 import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
 import initMetrics from './metrics';
 import setupRoutes from './routes';
+
+// Multipart parse errors are thrown synchronously from busboy's stream writer
+// (see https://github.com/mscdex/busboy), which bypasses multer's error
+// callback and Express's error middleware. Without a handler, a single
+// malformed upload request would terminate the process. Log to Sentry and
+// keep running for these known-recoverable cases; preserve default crash
+// behavior for anything else.
+const RECOVERABLE_UNCAUGHT_ERRORS = [
+  'Malformed part header',
+  'Unexpected end of form',
+  'Unexpected end of multipart data'
+];
+
+process.on('uncaughtException', (err: Error) => {
+  if (err?.message && RECOVERABLE_UNCAUGHT_ERRORS.some(m => err.message.includes(m))) {
+    capture(err);
+    return;
+  }
+  console.error('Uncaught exception:', err);
+  process.exit(1);
+});
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary

Busboy throws synchronously from `Multipart._write` on a malformed multipart payload. The throw bypasses multer's error callback and Express's error middleware, so a single bad upload terminates the server process.

Observed today at `21:56:26 UTC` in production logs:

```
Error: Malformed part header
    at SBMH.ssCb [as _cb] (busboy/lib/types/multipart.js:398:32)
    at feed (streamsearch/lib/sbmh.js:219:14)
    at Multipart._write (busboy/lib/types/multipart.js:567:19)
    at IncomingMessage.ondata (node:internal/streams/readable:754:22)
    at IncomingMessage.emit (node:domain:489:12)
```

The process exited with code 1 and was restarted by yarn ~5s later — visible to clients as a brief outage.

## Fix

Install a `process.uncaughtException` handler in `src/index.ts` that:

- Captures the known recoverable parse errors (`Malformed part header`, `Unexpected end of form`, `Unexpected end of multipart data`) via Sentry and keeps the server running.
- Preserves the default crash-on-uncaught behavior for anything else (logs to stderr and `process.exit(1)`).

The handler list is explicit so this acts as a targeted shield rather than a blanket safety net.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [ ] Manual repro: send a malformed multipart payload and verify the server stays up across a few invocations
- [ ] Sentry confirms the captured `Error: Malformed part header` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)