### PR TITLE
fix: surface raw error response in 4everland provider

### DIFF
--- a/src/providers/ipfs/4everland.ts
+++ b/src/providers/ipfs/4everland.ts
@@ -30,10 +30,9 @@ async function withResponseDetails<T>(op: string, run: () => Promise<T>): Promis
   } catch (err: any) {
     const status = err?.$response?.statusCode ?? err?.$metadata?.httpStatusCode;
     const rawBody = extractBody(err?.$response?.body);
-    const parts = [
-      status && `status=${status}`,
-      rawBody && `body=${rawBody.slice(0, 500)}`
-    ].filter(Boolean);
+    const parts = [status && `status=${status}`, rawBody && `body=${rawBody.slice(0, 500)}`].filter(
+      Boolean
+    );
     const fallback = err instanceof Error ? err.message : String(err);
     const detail = parts.length ? parts.join(' ') : fallback;
     throw new Error(`${provider} ${op} failed${detail ? `: ${detail}` : ''}`, { cause: err });

--- a/src/providers/ipfs/4everland.ts
+++ b/src/providers/ipfs/4everland.ts
@@ -13,6 +13,13 @@ const client = new S3({
   }
 });
 
+function extractBody(body: unknown): string | undefined {
+  if (typeof body === 'string') return body;
+  if (Buffer.isBuffer(body)) return body.toString('utf-8');
+  if (body instanceof Uint8Array) return Buffer.from(body).toString('utf-8');
+  return undefined;
+}
+
 // 4everland is S3-compatible but not real S3, so error responses are not
 // always valid XML. When the AWS SDK fails to deserialize an error body it
 // throws a generic "Cannot read properties of undefined (reading '#text')"
@@ -22,11 +29,14 @@ async function withResponseDetails<T>(op: string, run: () => Promise<T>): Promis
     return await run();
   } catch (err: any) {
     const status = err?.$response?.statusCode ?? err?.$metadata?.httpStatusCode;
-    const rawBody = err?.$response?.body?.toString?.('utf-8');
-    const detail = [status && `status=${status}`, rawBody && `body=${rawBody.slice(0, 500)}`]
-      .filter(Boolean)
-      .join(' ');
-    throw new Error(`4everland ${op} failed${detail ? `: ${detail}` : ''}`, { cause: err });
+    const rawBody = extractBody(err?.$response?.body);
+    const parts = [
+      status && `status=${status}`,
+      rawBody && `body=${rawBody.slice(0, 500)}`
+    ].filter(Boolean);
+    const fallback = err instanceof Error ? err.message : String(err);
+    const detail = parts.length ? parts.join(' ') : fallback;
+    throw new Error(`${provider} ${op} failed${detail ? `: ${detail}` : ''}`, { cause: err });
   }
 }
 

--- a/src/providers/ipfs/4everland.ts
+++ b/src/providers/ipfs/4everland.ts
@@ -13,18 +13,37 @@ const client = new S3({
   }
 });
 
+// 4everland is S3-compatible but not real S3, so error responses are not
+// always valid XML. When the AWS SDK fails to deserialize an error body it
+// throws a generic "Cannot read properties of undefined (reading '#text')"
+// that hides the actual upstream status/body. Surface them here.
+async function withResponseDetails<T>(op: string, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (err: any) {
+    const status = err?.$response?.statusCode ?? err?.$metadata?.httpStatusCode;
+    const rawBody = err?.$response?.body?.toString?.('utf-8');
+    const detail = [status && `status=${status}`, rawBody && `body=${rawBody.slice(0, 500)}`]
+      .filter(Boolean)
+      .join(' ');
+    throw new Error(`4everland ${op} failed${detail ? `: ${detail}` : ''}`, { cause: err });
+  }
+}
+
 export async function set(data: Buffer | object) {
   const payload = data instanceof Buffer ? data : JSON.stringify(data);
   const params = {
     Bucket: process.env.EVER_BUCKET_NAME,
     Key: sha256(payload)
   };
-  await client.putObject({
-    ...params,
-    Body: payload,
-    ContentType: data instanceof Buffer ? undefined : 'application/json; charset=utf-8'
-  });
-  const result = await client.headObject(params);
+  await withResponseDetails('putObject', () =>
+    client.putObject({
+      ...params,
+      Body: payload,
+      ContentType: data instanceof Buffer ? undefined : 'application/json; charset=utf-8'
+    })
+  );
+  const result = await withResponseDetails('headObject', () => client.headObject(params));
   const cid = JSON.parse(result.ETag || 'null');
 
   return { cid, provider };


### PR DESCRIPTION
## Summary

Wrap `client.putObject` / `client.headObject` in the 4everland provider so failed S3 calls re-throw an error carrying the actual HTTP status code and a truncated raw response body, instead of the generic AWS SDK deserialization error.

## Why

4everland is S3-compatible but not real S3. When it returns a non-XML error body (e.g. during a 503 outage), the AWS SDK's XML deserializer throws `TypeError: Cannot read properties of undefined (reading '#text')`, which hides the upstream status and body and makes the failure unactionable in Sentry.

Surfaced by Sentry: [PINEAPPLE-3C](https://snapshot-labs.sentry.io/issues/PINEAPPLE-3C) (not auto-closed — keeping it open until a follow-up event confirms the new error format).

## Investigation

- **Operation**: write (`PutObject`) — not a read. Stack trace points to `de_PutObjectCommandError`.
- **Upstream cause**: 4everland returned HTTP **503** during a transient outage (visible in the Sentry breadcrumbs). The body wasn't valid S3 XML, so the SDK's XML parser blew up trying to extract `#text`.
- **Endpoint health now**: a fresh authenticated `PutObject` of a new test payload succeeded in ~870ms — so the endpoint is back to normal. (The original request couldn't be replayed: the body was the user's upload and isn't captured anywhere; only the sha256 key survives in the breadcrumbs.)
- **Data loss**: `HeadObject` on the original key (`4e2b6d31...`) returns **404** — the write was genuinely lost on 4everland. The user-facing upload likely still succeeded via `Promise.any()` across the other providers (fleek/infura/web3storage), but 4everland's copy is missing.

## Test plan

- [x] `yarn typecheck` passes
- [x] CI lint + test pass
- [ ] On next 4everland failure, Sentry shows `4everland putObject failed: status=… body=…` (or `status=…`, or the original `err.message` for non-HTTP failures) instead of `'#text'`