### PR TITLE
chore: scope tsc compilation to src/ only

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
     "inlineSources": true,
     "sourceRoot": "/",
     "typeRoots": ["./node_modules/@types", "./test/setup"]
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- Adds `"include": ["src/**/*"]` to `tsconfig.json` so `tsc` no longer compiles `test/**/*.test.ts` into `dist/test/`.

## Why
Without `include`, tsc defaults to compiling every `.ts` file under `rootDir`, leaving stale test artifacts in `dist/`. The existing `typeRoots` entry for `./test/setup` is preserved (ambient types only, not affected by `include`).

## Verification
- `rm -rf dist && yarn build` — no `*.test.js` / `*.spec.js` files in `dist/`
- `yarn typecheck` passes