### PR TITLE
chore: move CI to Node 22

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   create-sentry-release:
+    strategy:
+      matrix:
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/create-sentry-release.yml@main
     secrets: inherit
     with:
       project: pineapple
+      target: ${{ matrix.target }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,5 +4,10 @@ on: [push]
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
+    with:
+      target: ${{ matrix.target }}
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '22'
           cache: 'yarn'
       - run: yarn
       - run: yarn test

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "prettier": "^3.0.1",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1"
+  },
+  "engines": {
+    "node": ">=22.6.0"
   }
 }


### PR DESCRIPTION
## What

Move CI to Node 22 (Active LTS until Apr 2027):

- Workflow `target` set to `'22'` on lint, test, and create-sentry-release

## Why

Node 18 is EOL. Newer `@snapshot-labs/eslint-config` requires `eslint-visitor-keys@5` whose engine needs `^20.19.0 || ^22.13.0 || >=24` — bumping CI to Node 22 unblocks the dependabot bump. Matches `blockfinder#505` (already merged) and `sx-monorepo` (already on Node 22).

## Test

CI `lint (22)` + `test (22)` should both go green on Node 22.

## ⚠️ Known blocker

`sharp@^0.32.4` has no prebuilt binary for Node 22 (sharp prebuilds start at 0.33+). `yarn install` on Node 22 may fail until `sharp` is bumped to `^0.33` (latest 0.34.5). Recommend a separate `chore(deps): bump sharp` PR landing first.