### PR TITLE
style: apply prettier printWidth 80

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     allow:
       # Allow updates for snapshot.js only
-      - dependency-name: "@snapshot-labs/*"
+      - dependency-name: '@snapshot-labs/*'
     groups:
       snapshot:
         patterns:
-          - "@snapshot-labs/*"
+          - '@snapshot-labs/*'

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ All endpoints will respond with a [JSON-RPC 2.0](https://www.jsonrpc.org/specifi
 }
 ```
 
-| Description                                                     | `CODE` | `MESSAGE`                                   |
-| --------------------------------------------------------------- | ------ | ------------------------------------------- |
-| Uploaded file exceed 1MB                                        | 400    | File too large                              |
-| Uploaded image file is not an image                             | 415    | Unsupported file type                       |
-| Uploaded payload does not contain a fileSize                    | 400    | No file submitted                           |
-| Server error                                                    | 500    | (Will depend on the error)                  |                 |
+| Description                                  | `CODE` | `MESSAGE`                  |
+| -------------------------------------------- | ------ | -------------------------- | --- |
+| Uploaded file exceed 1MB                     | 400    | File too large             |
+| Uploaded image file is not an image          | 415    | Unsupported file type      |
+| Uploaded payload does not contain a fileSize | 400    | No file submitted          |
+| Server error                                 | 500    | (Will depend on the error) |     |

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0-beta.18",
-    "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
+    "@snapshot-labs/prettier-config": "^0.1.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.3",
     "@types/multer": "^1.4.7",

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -27,13 +27,17 @@ const providersJsonCount = new client.Gauge({
   name: 'providers_json_count',
   help: 'Number of providers used for JSON pinning.'
 });
-providersJsonCount.set(IPFS_JSON_PROVIDERS.filter(p => p.isConfigured()).length);
+providersJsonCount.set(
+  IPFS_JSON_PROVIDERS.filter(p => p.isConfigured()).length
+);
 
 const providersImageCount = new client.Gauge({
   name: 'providers_image_count',
   help: 'Number of providers used for image pinning.'
 });
-providersImageCount.set(IPFS_IMAGE_PROVIDERS.filter(p => p.isConfigured()).length);
+providersImageCount.set(
+  IPFS_IMAGE_PROVIDERS.filter(p => p.isConfigured()).length
+);
 
 export const timeProvidersUpload = new client.Histogram({
   name: 'providers_upload_duration_seconds',
@@ -106,7 +110,10 @@ const providersInstrumentation = (req, res, next) => {
   const oldJson = res.json;
   res.json = body => {
     if (res.statusCode === 200 && body) {
-      providersReturnCount.inc({ name: body.result?.provider || body.provider, type });
+      providersReturnCount.inc({
+        name: body.result?.provider || body.provider,
+        type
+      });
     }
 
     res.locals.body = body;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -7,7 +7,11 @@ import {
   IMAGE_PROVIDERS as SWARM_IMAGE_PROVIDERS,
   JSON_PROVIDERS as SWARM_JSON_PROVIDERS
 } from './swarm';
-import { countOpenProvidersRequest, providersUploadSize, timeProvidersUpload } from '../metrics';
+import {
+  countOpenProvidersRequest,
+  providersUploadSize,
+  timeProvidersUpload
+} from '../metrics';
 
 type ProviderType = 'image' | 'json';
 type Protocol = 'ipfs' | 'swarm';
@@ -35,10 +39,14 @@ export default async function uploadToProviders(
   }
 
   if (!PROVIDERS[protocol][type]?.length) {
-    throw new Error(`Unsupported provider type: ${type} for protocol: ${protocol}`);
+    throw new Error(
+      `Unsupported provider type: ${type} for protocol: ${protocol}`
+    );
   }
 
-  const configuredProviders = PROVIDERS[protocol][type].filter(p => p.isConfigured());
+  const configuredProviders = PROVIDERS[protocol][type].filter(p =>
+    p.isConfigured()
+  );
 
   try {
     return await Promise.any(
@@ -50,8 +58,11 @@ export default async function uploadToProviders(
           countOpenProvidersRequest.inc({ name, type });
 
           const result = await set(params);
-          const size = (params instanceof Buffer ? params : Buffer.from(JSON.stringify(params)))
-            .length;
+          const size = (
+            params instanceof Buffer
+              ? params
+              : Buffer.from(JSON.stringify(params))
+          ).length;
           providersUploadSize.inc({ name, type }, size);
           status = 1;
           console.log(`JSON pinned: ${result.provider} - ${result.cid}`);
@@ -80,7 +91,9 @@ export default async function uploadToProviders(
         throw e.errors[0];
       }
 
-      throw new Error(`Unable to upload ${type} to ${protocol}: all providers failed`);
+      throw new Error(
+        `Unable to upload ${type} to ${protocol}: all providers failed`
+      );
     }
     throw e;
   }

--- a/src/providers/ipfs/4everland.ts
+++ b/src/providers/ipfs/4everland.ts
@@ -24,18 +24,24 @@ function extractBody(body: unknown): string | undefined {
 // always valid XML. When the AWS SDK fails to deserialize an error body it
 // throws a generic "Cannot read properties of undefined (reading '#text')"
 // that hides the actual upstream status/body. Surface them here.
-async function withResponseDetails<T>(op: string, run: () => Promise<T>): Promise<T> {
+async function withResponseDetails<T>(
+  op: string,
+  run: () => Promise<T>
+): Promise<T> {
   try {
     return await run();
   } catch (err: any) {
     const status = err?.$response?.statusCode ?? err?.$metadata?.httpStatusCode;
     const rawBody = extractBody(err?.$response?.body);
-    const parts = [status && `status=${status}`, rawBody && `body=${rawBody.slice(0, 500)}`].filter(
-      Boolean
-    );
+    const parts = [
+      status && `status=${status}`,
+      rawBody && `body=${rawBody.slice(0, 500)}`
+    ].filter(Boolean);
     const fallback = err instanceof Error ? err.message : String(err);
     const detail = parts.length ? parts.join(' ') : fallback;
-    throw new Error(`${provider} ${op} failed${detail ? `: ${detail}` : ''}`, { cause: err });
+    throw new Error(`${provider} ${op} failed${detail ? `: ${detail}` : ''}`, {
+      cause: err
+    });
   }
 }
 
@@ -49,10 +55,13 @@ export async function set(data: Buffer | object) {
     client.putObject({
       ...params,
       Body: payload,
-      ContentType: data instanceof Buffer ? undefined : 'application/json; charset=utf-8'
+      ContentType:
+        data instanceof Buffer ? undefined : 'application/json; charset=utf-8'
     })
   );
-  const result = await withResponseDetails('headObject', () => client.headObject(params));
+  const result = await withResponseDetails('headObject', () =>
+    client.headObject(params)
+  );
   const cid = JSON.parse(result.ETag || 'null');
 
   return { cid, provider };

--- a/src/providers/ipfs/infura.ts
+++ b/src/providers/ipfs/infura.ts
@@ -9,9 +9,9 @@ const client = create({
   protocol: 'https',
   timeout: 10e3,
   headers: {
-    authorization: `Basic ${Buffer.from(`${INFURA_PROJECT_ID}:${INFURA_PROJECT_SECRET}`).toString(
-      'base64'
-    )}`
+    authorization: `Basic ${Buffer.from(
+      `${INFURA_PROJECT_ID}:${INFURA_PROJECT_SECRET}`
+    ).toString('base64')}`
   }
 });
 

--- a/src/providers/swarm/swarmy.ts
+++ b/src/providers/swarm/swarmy.ts
@@ -13,22 +13,27 @@ export function isConfigured(): boolean {
   return !!SWARMY_API_KEY;
 }
 
-export async function set(data: Buffer | object): Promise<{ cid: string; provider: string }> {
+export async function set(
+  data: Buffer | object
+): Promise<{ cid: string; provider: string }> {
   if (data instanceof Buffer) {
     throw new Error('Swarmy only supports JSON data');
   }
 
-  const response = await fetch(`https://api.swarmy.cloud/api/data/utf8?k=${SWARMY_API_KEY}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      name: 'filename.json',
-      contentType: 'application/json',
-      utf8: JSON.stringify(data)
-    })
-  });
+  const response = await fetch(
+    `https://api.swarmy.cloud/api/data/utf8?k=${SWARMY_API_KEY}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        name: 'filename.json',
+        contentType: 'application/json',
+        utf8: JSON.stringify(data)
+      })
+    }
+  );
 
   if (!response.ok) {
     throw new Error(`Swarm upload failed: ${response.statusText}`);

--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -51,7 +51,11 @@ router.get('^/ipfs/:cid([0-9a-zA-Z]+)$', useProxyCache, async (req, res) => {
             return Promise.reject(response.status);
           }
 
-          if (!['text/plain', 'application/json'].includes(response.headers.get('content-type'))) {
+          if (
+            !['text/plain', 'application/json'].includes(
+              response.headers.get('content-type')
+            )
+          ) {
             return Promise.reject(UNSUPPORTED_FILE_TYPE);
           }
 
@@ -75,7 +79,9 @@ router.get('^/ipfs/:cid([0-9a-zA-Z]+)$', useProxyCache, async (req, res) => {
     return res.json(result.json);
   } catch (e) {
     if (e instanceof AggregateError) {
-      return res.status(e.errors.includes(UNSUPPORTED_FILE_TYPE) ? 415 : 400).json();
+      return res
+        .status(e.errors.includes(UNSUPPORTED_FILE_TYPE) ? 415 : 400)
+        .json();
     }
 
     capture(e);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,12 @@ export function rpcSuccess(res: Response, result: any, id = '') {
   });
 }
 
-export function rpcError(res: Response, code: number, e: Error | string, id = null) {
+export function rpcError(
+  res: Response,
+  code: number,
+  e: Error | string,
+  id = null
+) {
   res.status(code).json({
     jsonrpc: '2.0',
     error: {

--- a/test/e2e/proxy.test.ts
+++ b/test/e2e/proxy.test.ts
@@ -27,7 +27,9 @@ describe('GET /ipfs/:cid', () => {
 
           expect(response.body).toEqual(cachedContent);
           expect(response.statusCode).toBe(200);
-          expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+          expect(response.headers['content-type']).toBe(
+            'application/json; charset=utf-8'
+          );
           expect(await get(cid)).toEqual(cachedContent);
         });
       } else {
@@ -42,7 +44,9 @@ describe('GET /ipfs/:cid', () => {
 
           expect(response.body).toEqual(content);
           expect(response.statusCode).toBe(200);
-          expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+          expect(response.headers['content-type']).toBe(
+            'application/json; charset=utf-8'
+          );
           expect(await get(cid)).toEqual(response.body);
         });
       } else {

--- a/test/e2e/uploadImage.test.ts
+++ b/test/e2e/uploadImage.test.ts
@@ -103,7 +103,10 @@ describe('POST /upload', () => {
         const pngBuffer = await sharp(imageBuffer).png().toBuffer();
         // @ts-expect-error - jest-image-snapshot types not properly configured
         expect(pngBuffer).toMatchImageSnapshot({
-          customSnapshotIdentifier: `upload-${filename.replace(/\./g, '-')}-to-webp`,
+          customSnapshotIdentifier: `upload-${filename.replace(
+            /\./g,
+            '-'
+          )}-to-webp`,
           failureThreshold: 0.01,
           failureThresholdType: 'percent'
         });

--- a/test/e2e/uploadJson.test.ts
+++ b/test/e2e/uploadJson.test.ts
@@ -6,7 +6,10 @@ import { createApp } from '../helpers/app';
 const IPFS_JSON_PROVIDER_NAMES = IPFS_JSON_PROVIDERS.map(p => p.provider);
 const SWARM_JSON_PROVIDER_NAMES = SWARM_JSON_PROVIDERS.map(p => p.provider);
 
-const JSON_PROVIDER_NAMES = [...IPFS_JSON_PROVIDER_NAMES, ...SWARM_JSON_PROVIDER_NAMES];
+const JSON_PROVIDER_NAMES = [
+  ...IPFS_JSON_PROVIDER_NAMES,
+  ...SWARM_JSON_PROVIDER_NAMES
+];
 
 describe('POST /', () => {
   let app: any;
@@ -95,7 +98,9 @@ describe('POST /', () => {
       });
 
       it('returns a 400 error on empty body', async () => {
-        const response = await request(app).post('/').send({ protocol: 'swarm' });
+        const response = await request(app)
+          .post('/')
+          .send({ protocol: 'swarm' });
 
         expect(response.statusCode).toBe(400);
         expect(response.body.error.message).toBe('Malformed body');

--- a/test/integration/providers/index.test.ts
+++ b/test/integration/providers/index.test.ts
@@ -34,7 +34,9 @@ describe('providers', () => {
   }
 
   const providerPayload: { name: string; provider: any; idVersion: string }[] =
-    buildProviderPayload([Fleek, Pinata], 'v0').concat(buildProviderPayload([FourEverland], 'v1'));
+    buildProviderPayload([Fleek, Pinata], 'v0').concat(
+      buildProviderPayload([FourEverland], 'v1')
+    );
 
   describe.each(providerPayload)('$name', ({ name, provider, idVersion }) => {
     if (!provider.isConfigured()) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1898,10 +1898,10 @@
   dependencies:
     "@snapshot-labs/eslint-config-base" "^0.1.0-beta.18"
 
-"@snapshot-labs/prettier-config@^0.1.0-beta.7":
-  version "0.1.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
-  integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
+"@snapshot-labs/prettier-config@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0.tgz#f0eafa4a3aed6a7fabaf88c016659f3343041071"
+  integrity sha512-8MYAHuewlAdJs55f94qQtEs/WLFmjgYfuIVb1iJPa9gUZauHEXMzbVpKZfnkQsgpwwcXxq9hzg0S/OeOkgj3+w==
 
 "@snapshot-labs/snapshot-metrics@^1.4.1":
   version "1.4.1"


### PR DESCRIPTION
## What

Sets Prettier's `printWidth` to **80** and reformats the codebase.

pineapple consumes the shared `@snapshot-labs/prettier-config` (via the `prettier` field in `package.json`), which on `master` is pinned to `^0.1.0-beta.7` and overrides `printWidth: 100`. The non-beta `0.1.0` release of that shared config drops the `printWidth` override, so Prettier falls back to its built-in default of **80**. This PR bumps the shared config and lands the (large) reflow churn **on its own**, so the upcoming ESLint 9 migration (#249) stays a clean, behavior-focused diff.

## How

- Bumped `@snapshot-labs/prettier-config` from `^0.1.0-beta.7` to `^0.1.0` in `devDependencies` and regenerated the lockfile. `0.1.0` no longer sets `printWidth`, so Prettier uses its default of 80 (verified: the installed config exposes no `printWidth`, and `prettier.resolveConfig` returns no width override).
- Kept the existing `"prettier": "@snapshot-labs/prettier-config"` field in `package.json` (unchanged). No local prettier config file added.
- Ran `prettier --write` across `src/**/*.ts`, `test/**/*.ts`, and the Markdown/YAML files (`README.md`, `.github/dependabot.yml`).

Only `@snapshot-labs/prettier-config` is bumped — **no** eslint / eslint-config / eslint.config.mjs / lint-script / engines changes. Those stay in #249.

This is formatting-only — no behavior changes.

## Validation

- `yarn install` ✅
- `yarn lint` (still ESLint 8 on this branch) ✅
- `yarn typecheck` ✅
- `yarn build` ✅
- `prettier --check` ✅ (all files at width 80)
- Tests ✅ (unit/integration pass; e2e upload specs need live provider creds and are skipped, same as `master`)

## Follow-up

This isolates the reflow churn ahead of the ESLint 9 migration. After this lands, **#249 will be rebased onto `master`** and its diff will then contain only the ESLint 9 changes (no standalone 80-reflow).