### PR TITLE
test: skip live-provider e2e when credentials are absent

### DIFF
--- a/test/e2e/uploadImage.test.ts
+++ b/test/e2e/uploadImage.test.ts
@@ -18,6 +18,20 @@ const isValidCid = (cid: string): boolean => {
 
 const IMAGE_PROVIDER_NAMES = IPFS_IMAGE_PROVIDERS.map(p => p.provider);
 
+// Image uploads go to the credential-gated 4everland IPFS provider. GitHub does
+// not expose repo secrets to Dependabot PRs, so the env vars are empty there and
+// these uploads fail with HTTP 500. Guard the upload blocks so they are skipped
+// (not failed) when the creds are absent, while still running on master.
+const hasIpfsCreds = Boolean(
+  process.env.EVER_API_KEY && process.env.EVER_API_SECRET
+);
+
+if (!hasIpfsCreds) {
+  console.warn(
+    'Skipping image upload e2e: EVER_API_KEY / EVER_API_SECRET not set'
+  );
+}
+
 describe('POST /upload', () => {
   let app: any;
 
@@ -59,21 +73,74 @@ describe('POST /upload', () => {
     });
   });
 
-  describe('when uploading image files', () => {
-    const supportedFormats = [
-      { format: 'PNG', filename: 'valid.png' },
-      { format: 'JPEG', filename: 'valid.jpg' },
-      { format: 'GIF', filename: 'valid.gif' },
-      { format: 'WebP', filename: 'valid.webp' },
-      { format: 'TIFF', filename: 'valid.tiff' }
-    ];
+  (hasIpfsCreds ? describe : describe.skip)(
+    'when uploading image files',
+    () => {
+      const supportedFormats = [
+        { format: 'PNG', filename: 'valid.png' },
+        { format: 'JPEG', filename: 'valid.jpg' },
+        { format: 'GIF', filename: 'valid.gif' },
+        { format: 'WebP', filename: 'valid.webp' },
+        { format: 'TIFF', filename: 'valid.tiff' }
+      ];
 
-    it.each(supportedFormats)(
-      'should successfully upload and convert $format to WebP with valid CID',
-      async ({ filename }) => {
+      it.each(supportedFormats)(
+        'should successfully upload and convert $format to WebP with valid CID',
+        async ({ filename }) => {
+          const response = await request(app)
+            .post('/upload')
+            .attach('file', path.join(__dirname, `./fixtures/${filename}`));
+
+          // Step 1: Verify API response
+          expect(response.statusCode).toBe(200);
+          expect(response.body.jsonrpc).toBe('2.0');
+          expect(isValidCid(response.body.result.cid)).toBe(true);
+          expect(IMAGE_PROVIDER_NAMES).toContain(response.body.result.provider);
+
+          // Step 2: Verify IPFS gateway retrieval
+          const gatewayUrl = `https://snapshot.4everland.link/ipfs/${response.body.result.cid}`;
+          const gatewayResponse = await fetch(gatewayUrl);
+
+          expect(gatewayResponse.ok).toBe(true);
+          expect(gatewayResponse.headers.get('content-type')).toMatch(
+            /^image\//
+          );
+
+          // Step 3: Verify content format and processing
+          const imageBuffer = await gatewayResponse.buffer();
+          const originalMetadata = await sharp(
+            path.join(__dirname, `./fixtures/${filename}`)
+          ).metadata();
+          const metadata = await sharp(imageBuffer).metadata();
+
+          expect(metadata.format).toBe('webp');
+          expect(metadata.width).toBe(originalMetadata.width);
+          expect(metadata.height).toBe(originalMetadata.height);
+
+          // Step 4: Visual verification with snapshot testing
+          const pngBuffer = await sharp(imageBuffer).png().toBuffer();
+          // @ts-expect-error - jest-image-snapshot types not properly configured
+          expect(pngBuffer).toMatchImageSnapshot({
+            customSnapshotIdentifier: `upload-${filename.replace(
+              /\./g,
+              '-'
+            )}-to-webp`,
+            failureThreshold: 0.01,
+            failureThresholdType: 'percent'
+          });
+        },
+        30000
+      );
+    }
+  );
+
+  (hasIpfsCreds ? describe : describe.skip)(
+    'when uploading large images',
+    () => {
+      it('should resize large images to max dimension with correct CID', async () => {
         const response = await request(app)
           .post('/upload')
-          .attach('file', path.join(__dirname, `./fixtures/${filename}`));
+          .attach('file', path.join(__dirname, './fixtures/large-image.jpg'));
 
         // Step 1: Verify API response
         expect(response.statusCode).toBe(200);
@@ -88,68 +155,23 @@ describe('POST /upload', () => {
         expect(gatewayResponse.ok).toBe(true);
         expect(gatewayResponse.headers.get('content-type')).toMatch(/^image\//);
 
-        // Step 3: Verify content format and processing
+        // Step 3: Verify content format and resize processing
         const imageBuffer = await gatewayResponse.buffer();
-        const originalMetadata = await sharp(
-          path.join(__dirname, `./fixtures/${filename}`)
-        ).metadata();
         const metadata = await sharp(imageBuffer).metadata();
 
         expect(metadata.format).toBe('webp');
-        expect(metadata.width).toBe(originalMetadata.width);
-        expect(metadata.height).toBe(originalMetadata.height);
+        expect(metadata.width).toBeLessThanOrEqual(MAX_IMAGE_DIMENSION);
+        expect(metadata.height).toBeLessThanOrEqual(MAX_IMAGE_DIMENSION);
 
         // Step 4: Visual verification with snapshot testing
         const pngBuffer = await sharp(imageBuffer).png().toBuffer();
         // @ts-expect-error - jest-image-snapshot types not properly configured
         expect(pngBuffer).toMatchImageSnapshot({
-          customSnapshotIdentifier: `upload-${filename.replace(
-            /\./g,
-            '-'
-          )}-to-webp`,
+          customSnapshotIdentifier: 'large-image-resized-to-webp',
           failureThreshold: 0.01,
           failureThresholdType: 'percent'
         });
-      },
-      30000
-    );
-  });
-
-  describe('when uploading large images', () => {
-    it('should resize large images to max dimension with correct CID', async () => {
-      const response = await request(app)
-        .post('/upload')
-        .attach('file', path.join(__dirname, './fixtures/large-image.jpg'));
-
-      // Step 1: Verify API response
-      expect(response.statusCode).toBe(200);
-      expect(response.body.jsonrpc).toBe('2.0');
-      expect(isValidCid(response.body.result.cid)).toBe(true);
-      expect(IMAGE_PROVIDER_NAMES).toContain(response.body.result.provider);
-
-      // Step 2: Verify IPFS gateway retrieval
-      const gatewayUrl = `https://snapshot.4everland.link/ipfs/${response.body.result.cid}`;
-      const gatewayResponse = await fetch(gatewayUrl);
-
-      expect(gatewayResponse.ok).toBe(true);
-      expect(gatewayResponse.headers.get('content-type')).toMatch(/^image\//);
-
-      // Step 3: Verify content format and resize processing
-      const imageBuffer = await gatewayResponse.buffer();
-      const metadata = await sharp(imageBuffer).metadata();
-
-      expect(metadata.format).toBe('webp');
-      expect(metadata.width).toBeLessThanOrEqual(MAX_IMAGE_DIMENSION);
-      expect(metadata.height).toBeLessThanOrEqual(MAX_IMAGE_DIMENSION);
-
-      // Step 4: Visual verification with snapshot testing
-      const pngBuffer = await sharp(imageBuffer).png().toBuffer();
-      // @ts-expect-error - jest-image-snapshot types not properly configured
-      expect(pngBuffer).toMatchImageSnapshot({
-        customSnapshotIdentifier: 'large-image-resized-to-webp',
-        failureThreshold: 0.01,
-        failureThresholdType: 'percent'
-      });
-    }, 30000);
-  });
+      }, 30000);
+    }
+  );
 });

--- a/test/e2e/uploadJson.test.ts
+++ b/test/e2e/uploadJson.test.ts
@@ -11,6 +11,25 @@ const JSON_PROVIDER_NAMES = [
   ...SWARM_JSON_PROVIDER_NAMES
 ];
 
+// These suites upload to real, credential-gated providers (4everland for IPFS,
+// Swarmy for Swarm). GitHub does not expose repo secrets to Dependabot PRs, so
+// the env vars are empty there and the upload requests fail with HTTP 500.
+// Guard the credential-dependent blocks so they are skipped (not failed) when
+// the relevant creds are absent, while still running on master / normal PRs.
+const hasIpfsCreds = Boolean(
+  process.env.EVER_API_KEY && process.env.EVER_API_SECRET
+);
+const hasSwarmCreds = Boolean(process.env.SWARMY_API_KEY);
+
+if (!hasIpfsCreds) {
+  console.warn(
+    'Skipping IPFS upload e2e: EVER_API_KEY / EVER_API_SECRET not set'
+  );
+}
+if (!hasSwarmCreds) {
+  console.warn('Skipping Swarm upload e2e: SWARMY_API_KEY not set');
+}
+
 describe('POST /', () => {
   let app: any;
 
@@ -19,36 +38,39 @@ describe('POST /', () => {
   });
 
   describe('ipfs protocol', () => {
-    describe('when the payload is valid', () => {
-      it('returns a 200 status', async () => {
-        const response = await request(app)
-          .post('/')
-          .send({ params: { status: 'OK' } });
+    (hasIpfsCreds ? describe : describe.skip)(
+      'when the payload is valid',
+      () => {
+        it('returns a 200 status', async () => {
+          const response = await request(app)
+            .post('/')
+            .send({ params: { status: 'OK' } });
 
-        expect(response.statusCode).toBe(200);
-        expect(response.body.result).toHaveProperty(
-          'cid',
-          'bafkreib5epjzumf3omr7rth5mtcsz4ugcoh3ut4d46hx5xhwm4b3pqr2vi'
-        );
-        expect(JSON_PROVIDER_NAMES).toContain(response.body.result.provider);
-      }, 20e3);
+          expect(response.statusCode).toBe(200);
+          expect(response.body.result).toHaveProperty(
+            'cid',
+            'bafkreib5epjzumf3omr7rth5mtcsz4ugcoh3ut4d46hx5xhwm4b3pqr2vi'
+          );
+          expect(JSON_PROVIDER_NAMES).toContain(response.body.result.provider);
+        }, 20e3);
 
-      it('returns a 200 when protocol is ipfs', async () => {
-        const response = await request(app)
-          .post('/')
-          .send({
-            params: { status: 'OK' },
-            protocol: 'ipfs'
-          });
+        it('returns a 200 when protocol is ipfs', async () => {
+          const response = await request(app)
+            .post('/')
+            .send({
+              params: { status: 'OK' },
+              protocol: 'ipfs'
+            });
 
-        expect(response.statusCode).toBe(200);
-        expect(response.body.result).toHaveProperty(
-          'cid',
-          'bafkreib5epjzumf3omr7rth5mtcsz4ugcoh3ut4d46hx5xhwm4b3pqr2vi'
-        );
-        expect(JSON_PROVIDER_NAMES).toContain(response.body.result.provider);
-      }, 20e3);
-    });
+          expect(response.statusCode).toBe(200);
+          expect(response.body.result).toHaveProperty(
+            'cid',
+            'bafkreib5epjzumf3omr7rth5mtcsz4ugcoh3ut4d46hx5xhwm4b3pqr2vi'
+          );
+          expect(JSON_PROVIDER_NAMES).toContain(response.body.result.provider);
+        }, 20e3);
+      }
+    );
 
     describe('when the payload is not valid', () => {
       it('returns a 400 error on malformed json', async () => {
@@ -68,23 +90,26 @@ describe('POST /', () => {
   });
 
   describe('swarm protocol', () => {
-    describe('when the payload is valid', () => {
-      it('returns a 200 status when protocol is swarm', async () => {
-        const response = await request(app)
-          .post('/')
-          .send({
-            params: { status: 'OK' },
-            protocol: 'swarm'
-          });
+    (hasSwarmCreds ? describe : describe.skip)(
+      'when the payload is valid',
+      () => {
+        it('returns a 200 status when protocol is swarm', async () => {
+          const response = await request(app)
+            .post('/')
+            .send({
+              params: { status: 'OK' },
+              protocol: 'swarm'
+            });
 
-        expect(response.statusCode).toBe(200);
-        expect(response.body.result).toHaveProperty(
-          'cid',
-          '2f897e39ca12b83795d167384f87da2b4bc4ebab70755bfa2933496a4e5cb5c7'
-        );
-        expect(JSON_PROVIDER_NAMES).toContain(response.body.result.provider);
-      }, 20e3);
-    });
+          expect(response.statusCode).toBe(200);
+          expect(response.body.result).toHaveProperty(
+            'cid',
+            '2f897e39ca12b83795d167384f87da2b4bc4ebab70755bfa2933496a4e5cb5c7'
+          );
+          expect(JSON_PROVIDER_NAMES).toContain(response.body.result.provider);
+        }, 20e3);
+      }
+    );
 
     describe('when the payload is not valid', () => {
       it('returns a 400 error on malformed json', async () => {


### PR DESCRIPTION
## Problem

The `test` job runs e2e specs that upload to **real, credential-gated providers** (4everland for IPFS, Swarmy for Swarm), using env vars sourced from `${{ secrets.* }}` in `.github/workflows/test.yml`.

GitHub does **not** expose repo secrets to Dependabot PRs, so on those runs `EVER_API_KEY`, `EVER_API_SECRET`, `SWARMY_API_KEY`, etc. are empty → the upload requests get HTTP 500 → CI goes red. Dependabot bump #252 is currently failing for exactly this reason.

## Fix

Guard the credential-dependent upload blocks with a per-provider check:

```ts
const hasIpfsCreds = Boolean(process.env.EVER_API_KEY && process.env.EVER_API_SECRET);
const hasSwarmCreds = Boolean(process.env.SWARMY_API_KEY);
// ...
(hasIpfsCreds ? describe : describe.skip)('when the payload is valid', () => { ... });
```

- `test/e2e/uploadJson.test.ts` — IPFS "valid payload" block guarded on `EVER_*`; Swarm "valid payload" block guarded on `SWARMY_API_KEY`. The 400 validation blocks always run.
- `test/e2e/uploadImage.test.ts` — "uploading image files" and "uploading large images" guarded on `EVER_*`. The 400/415 validation blocks always run.
- A `console.warn` logs when a suite is skipped so it's visible in CI (not silently passing).
- `test/e2e/proxy.test.ts` already self-guards its cache tests on `AWS_REGION`, so it's left unchanged.

Net effect: **Dependabot PRs go green** (upload blocks skip, validation blocks pass); **real runs on master still execute the full e2e** because the secrets are present.

## Validation

With creds unset, the upload suites report as skipped and the run exits 0:

```
when uploading image files
  ○ skipped should successfully upload and convert PNG to WebP ...
Tests: 9 skipped, 8 passed, 17 total
Test Suites: 2 passed, 2 total
```

`yarn lint`, `yarn typecheck`, and `yarn build` all pass.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)